### PR TITLE
fix(shared): address PR #81 COPE regression findings

### DIFF
--- a/docs/story/economy.md
+++ b/docs/story/economy.md
@@ -891,7 +891,7 @@ Small gold tips (50–100g) from NPCs for information or returning lost items. F
 
 ### Post-Game (Dreamer's Fault, Level 45+)
 
-Gold becomes abundant. Tier 5 gear is non-purchasable (boss/quest only). The economy shifts from "can I afford this?" to "should I sell rare materials or save them for ultimate Forgewright recipes?" Gold surplus is intentional. Boss rush repeat clears provide repeatable gold income (1,000g / 2,500g / 5,000g per tier per [postgame.md](postgame.md)) — the only repeatable gold source in the game.
+Gold becomes abundant. Tier 5 gear is non-purchasable (boss/quest only). The economy shifts from "can I afford this?" to "should I sell rare materials or save them for ultimate Forgewright recipes?" Gold surplus is intentional. Boss rush repeat clears provide structured repeatable gold income (1,000g / 2,500g / 5,000g per tier per [postgame.md](postgame.md)). Dreamer's Fault enemy respawns (per [postgame.md](postgame.md)) also provide repeatable gold via drops.
 
 ---
 

--- a/docs/story/equipment.md
+++ b/docs/story/equipment.md
@@ -528,7 +528,7 @@ content. Not sold in any shop.
 | Warden's Core | Counter-attack on physical hit | Iron Warden | Post |
 | Keeper's Resolve | +15% Despair resistance, +5 MDEF | The Grey Keeper drop (Oasis C) | III |
 | The Pallor's Last | Massive stat boosts, 25% all incoming damage reduction | The Lingering (super boss) | Post |
-| Dreamer's Mark | Full Despair status immunity | Dreamer's Fault Floor 20 completion | Post |
+| Dreamer's Mark | Immunity to all status effects | Dreamer's Fault Floor 20 completion | Post |
 | Dreamer's Crest | +30 all stats | Cael's Echo (non-combat) | Post |
 | Warrior's Memento | ATK +10 | Boss Rush Tier 1 | Post |
 | Survivor's Memento | DEF +10, MDEF +10 | Boss Rush Tier 2 | Post |

--- a/docs/story/transport.md
+++ b/docs/story/transport.md
@@ -187,10 +187,11 @@ window maps to Act II's position in the story (~30--50% of the game).
   still exist inside the dungeon as traversal hazards with
   unpredictable destinations, but the NPC-operated city-to-city
   fast-travel service is suspended on all segments.
-- **Ley Stag:** Lost. Spirit animals flee as Pallor corruption spreads
-  through the ley lines. The Stag dissolves during the Interlude
-  transition cutscene — a visual moment where the party's ley bond
-  breaks. Cannot be summoned.
+- **Ley Stag:** Lost (if `stag_bonded` was set). Spirit animals flee
+  as Pallor corruption spreads through the ley lines. The Stag
+  dissolves during the Interlude transition cutscene — a visual
+  moment where the party's ley bond breaks. Cannot be summoned. If
+  the Stag was never bonded, this step is skipped.
 - **Ferry:** Disrupted. Bellhaven disrupted (per
   [dynamic-world.md](dynamic-world.md) — harbor economy collapsed,
   grey things washing ashore). Ferryman refuses: "The waters aren't
@@ -211,10 +212,11 @@ transformation more effectively than any cutscene.
 
 - **Rail:** Remains broken. Tunnels still a dungeon. No fast-travel.
 - **Ley Stag:** Returns when Torren rejoins the party (Act III reunion
-  event). The Stag re-manifests with grey-tinged ley energy (visual
-  corruption) but is mechanically identical (2x speed, no encounters).
-  Cannot enter the Pallor Wastes 10-mile radius — "The Stag shies
-  away. The ley energy here is wrong."
+  event), provided `stag_bonded` was set in Act II. The Stag
+  re-manifests with grey-tinged ley energy (visual corruption) but is
+  mechanically identical (2x speed, no encounters). Cannot enter the
+  Pallor Wastes 10-mile radius — "The Stag shies away. The ley energy
+  here is wrong." If the Stag was never bonded, it remains unavailable.
 - **Ferry:** Restored at Ashport only. Ferryman relocates from
   Bellhaven. Same route (Ashport ↔ Bellhaven) but only boardable from
   Ashport until Bellhaven stabilizes.
@@ -225,9 +227,9 @@ transformation more effectively than any cutscene.
 - **Rail:** Repair crews working (visible scaffolding at terminals).
   Not yet functional — NPC dialogue: "Months away from service." No
   gameplay rail travel.
-- **Ley Stag:** Fully restored. Grey tint fades, ley energy bright
-  again. No Pallor restriction (Wastes are gone). Full 2x speed,
-  no encounters everywhere accessible.
+- **Ley Stag:** Fully restored (if bonded). Grey tint fades, ley
+  energy bright again. No Pallor restriction (Wastes are gone). Full
+  2x speed, no encounters everywhere accessible.
 - **Ferry:** Both ports operational. Full service restored.
 - **Linewalk:** Still works.
 


### PR DESCRIPTION
## Summary

Fixes 3 regression issues found by COPE review of PR #81 (post-game issues batch).

- **Dreamer's Mark immunity scope:** equipment.md said "Full Despair status immunity" but sidequests.md (canonical) says "immunity to all status effects." Fixed to match sidequests.md.
- **transport.md Stag conditional:** events.md stag_lost (#55) and stag_returned (#56) now require stag_bonded, but transport.md described the Stag unconditionally in Interlude/Act III/Epilogue. Added conditional language to all three act entries.
- **economy.md repeatable gold:** Claimed boss rush was "the only repeatable gold source" but Dreamer's Fault enemies respawn per postgame.md. Fixed to acknowledge both sources.

### Files Changed
- `docs/story/equipment.md` — Dreamer's Mark effect corrected
- `docs/story/transport.md` — Stag conditional added to 3 act sections
- `docs/story/economy.md` — Repeatable gold claim corrected

## Test plan
- [x] `pnpm test` passes (44 tests)
- [x] `pnpm lint` passes (TypeScript type-check)
- [ ] Verify Dreamer's Mark "all status effects" matches sidequests.md
- [ ] Verify transport.md Stag conditionals match events.md flag guards
- [ ] Verify economy.md no longer claims boss rush is the only repeatable source

Generated with [Claude Code](https://claude.ai/code)
