### PR TITLE
feat(engine): wire party assembly — Lira+Sable join, Scenes 2-4 triggers

### DIFF
--- a/docs/analysis/game-dev-gaps.md
+++ b/docs/analysis/game-dev-gaps.md
@@ -965,11 +965,28 @@ smallest vertical slice (Ember Vein) that exercises every system.
 - [ ] Encounter data exists (fenmothers_hollow.json)
 - [ ] New enemy types (marsh_serpent, drowned_bones, ley_jellyfish, polluted_elemental)
 
-**Phase B: Opening Sequence (NOT STARTED)**
-- [ ] Ironmouth outpost map
-- [ ] Ember Vein F3 (Ancient Ruin floor, puzzles)
-- [ ] Scenes 1-4 (tutorial, Vaelith, Lira+Sable join, Dawn March credits)
-- [ ] Party starts with Edren+Cael only, others join during Act I
+**Phase B1: Party Assembly + Game Start (COMPLETE — 2026-04-09)**
+- [x] Party starts with Edren+Cael only (initialize_new_game unchanged)
+- [x] Lira+Sable join via carradan_ambush_survived flag in _check_party_joining_flags
+- [x] Lira+Sable added to STARTING_EQUIPMENT (empty — player equips)
+- [x] Scene 2 dialogue trigger on overworld (Vaelith encounter, requires vaelith_ember_vein)
+- [x] Scene 3 dialogue trigger on overworld (Ironmouth escape stub, sets carradan_ambush_survived)
+- [x] Scene 4 dialogue trigger on overworld (Dawn March, requires carradan_ambush_survived)
+- [x] Dialogue data uses existing files: vaelith_ember_vein.json, ironmouth_escape.json, dawn_march.json
+- [x] Overworld label for Ironmouth area
+- [x] Integration tests (test_opening_sequence.gd, ~20 tests)
+- [x] Design spec: docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
+
+**Phase B2: Ironmouth + F3 + Full Scenes (NOT STARTED)**
+- [ ] Ironmouth outpost map (.tscn with NPCs, Forgewright crates)
+- [ ] Ember Vein F3 (Ancient Ruin floor with geometric puzzles)
+- [ ] Full Scene 1 tutorial dialogue (all 1a-1e beats with combat)
+- [ ] Full Scene 3 Ironmouth escape (combat sequence with soldiers)
+- [ ] Opening credits visual sequence (title card, character names)
+- [ ] Dawn March forward-only walk mechanics
+- [ ] Arcanite gear preview (Edren's enhanced equipment that breaks)
+- [ ] Change new game start location from overworld to Ember Vein F1
+- [ ] Cael hidden stat spike (Pallor's first touch)
 
 **Phase C: Capital Completion (NOT STARTED)**
 - [ ] Remaining Valdris districts (Citizen's Walk, Court Quarter, Royal Keep, Eastern Wall)

--- a/docs/analysis/game-dev-gaps.md
+++ b/docs/analysis/game-dev-gaps.md
@@ -995,7 +995,7 @@ smallest vertical slice (Ember Vein) that exercises every system.
 - [ ] Act I finale flag: pendulum_to_capital
 
 **Notes:**
-- Party assembly now works: Edren+Cael at new game, Torren joins at Roothollow (Scene 5), Maren joins at Refuge (Scene 6). Lira+Sable join deferred to Phase B (Scenes 3-4).
+- Party assembly now works: Edren+Cael at new game, Lira+Sable join via carradan_ambush_survived flag (Phase B1, PR #132), Torren joins at Roothollow (Scene 5), Maren joins at Refuge (Scene 6).
 - Dialogue triggers use dialogue_scene_id metadata (loads from DataManager) instead of inline dialogue_data — scalable for large scenes.
 - required_flag metadata on triggers enables prerequisite flag checking (e.g., Scene 6 requires torren_joined).
 

--- a/docs/story/events.md
+++ b/docs/story/events.md
@@ -254,6 +254,7 @@ The game tracks world state through flags. Each flag, when set, cascades changes
 |---|-----------|---------|---------------|---------------|
 | 1 | `pendulum_discovered` | Party finds the Pendulum in the Ember Vein central chamber | Ember Vein dungeon marked complete. Ironmouth Carradan soldiers become hostile. Lira and Sable join the party during the escape. | Lira (joins), Sable (joins) |
 | 2 | `vaelith_ember_vein` | Vein Guardian defeated in the Ember Vein | Grey stranger NPCs appear in Valdris Crown with gossip dialogue about a charming traveler seen near the mine. | Vaelith (first appearance) |
+| 2b | `vaelith_scene_complete` | Scene 2 dialogue (Vaelith encounter on overworld) viewed after Ember Vein exit | Gates Scene 3 trigger — player must see Vaelith dialogue before Ironmouth escape. Implementation-level ordering flag. | — |
 | 3 | `carradan_ambush_survived` | Party defeats Carradan soldiers at Ironmouth exit | Ironmouth becomes inaccessible (Compact locks it down). Thornmere Wilds overworld opens. | Torren (findable at Roothollow) |
 | 39 | `opening_credits_seen` | Dawn march credits sequence ends at Wilds border | Tutorial complete. True game start. Prevents credits replay. Dawn march uses existing `vaelith_ember_vein` (flag 2) as prerequisite. | Edren, Cael, Lira, Sable |
 | 4 | `torren_joined` | Party reaches Roothollow; Torren agrees to guide them to Maren | Torren joins the party. Deep Path route to Maren's Refuge opens. Vessa's dialogue changes to warn about the Pendulum. | Torren (joins), Vessa (new dialogue) |

--- a/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
+++ b/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
@@ -63,12 +63,21 @@ New Game → Overworld (Edren + Cael)
 
 ```gdscript
 func _check_party_joining_flags() -> void:
-    if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("lira"):
-        PartyState.add_member("lira", _get_party_avg_level())
-        flash_location_name("Lira joined the party!")
-    if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("sable"):
-        PartyState.add_member("sable", _get_party_avg_level())
-        flash_location_name("Sable joined the party!")
+    if EventFlags.get_flag("carradan_ambush_survived"):
+        var added_lira: bool = false
+        var added_sable: bool = false
+        if not PartyState.has_member("lira"):
+            PartyState.add_member("lira", _get_party_avg_level())
+            added_lira = true
+        if not PartyState.has_member("sable"):
+            PartyState.add_member("sable", _get_party_avg_level())
+            added_sable = true
+        if added_lira and added_sable:
+            flash_location_name("Lira and Sable joined the party!")
+        elif added_lira:
+            flash_location_name("Lira joined the party!")
+        elif added_sable:
+            flash_location_name("Sable joined the party!")
     if EventFlags.get_flag("torren_joined") and not PartyState.has_member("torren"):
         PartyState.add_member("torren", _get_party_avg_level())
         flash_location_name("Torren joined the party!")
@@ -78,6 +87,7 @@ func _check_party_joining_flags() -> void:
 ```
 
 Both Lira and Sable join on the same flag (`carradan_ambush_survived`).
+A combined flash message avoids the second call overwriting the first.
 
 ### Ember Vein Exit Flag
 

--- a/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
+++ b/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
@@ -1,0 +1,216 @@
+# Opening Sequence Phase B1 — Design Spec
+
+> **Gap:** 4.4 Phase B1 (Party Assembly + Game Start Restructuring)
+> **Goal:** Wire correct party assembly flow: Edren+Cael at start,
+> Lira+Sable join via carradan_ambush_survived flag, Scene 2+4
+> dialogue triggers on overworld, Ember Vein exit sets story flags.
+
+---
+
+## 1. Scope
+
+### In Scope
+
+- Add `carradan_ambush_survived` flag check to `_check_party_joining_flags()`
+  for Lira+Sable party assembly
+- Create Scene 2 dialogue data (Vaelith encounter at mine exit)
+- Create Scene 4 dialogue data (Dawn March opening credits walk)
+- Add overworld dialogue triggers for Scenes 2, 3 (placeholder), and 4
+- Wire Ember Vein F4 exit to set `pendulum_discovered` and
+  `vaelith_ember_vein` flags
+- Add overworld Ironmouth placeholder trigger (Scene 3 stub) that sets
+  `carradan_ambush_survived` and adds Lira+Sable
+- Add starting equipment entries for Lira and Sable in STARTING_EQUIPMENT
+- Update all tests for the new party assembly flow
+- Update gap tracker with B1 complete + B2 remaining
+
+### Not In Scope (Deferred to Phase B2)
+
+| Item | Reason | Deferred To |
+|------|--------|-------------|
+| Ironmouth outpost map (.tscn) | Needs new tileset + NPC placements | 4.4 Phase B2 |
+| Ember Vein F3 (Ancient Ruin) | Complex floor with puzzles/key items | 4.4 Phase B2 |
+| Scene 1 full tutorial dialogue | Needs F3 + tutorial combat design | 4.4 Phase B2 |
+| Scene 3 escape combat sequence | Needs Ironmouth map + soldier enemies | 4.4 Phase B2 |
+| Opening credits camera walk | Needs cutscene system (gap 3.7) | 4.4 Phase B2 |
+| Dawn March forward-only walk | Needs special exploration mode | 4.4 Phase B2 |
+| Arcanite gear preview | Complex equipment mechanic | 4.4 Phase B2 |
+| Cael hidden stat spike | Needs Act II flag system | 4.5 |
+| Change new game start to Ember Vein | Needs F1-F4 fully playable | 4.4 Phase B2 |
+
+---
+
+## 2. Party Assembly Flow (After B1)
+
+```
+New Game → Overworld (Edren + Cael)
+  ↓ Walk to Ember Vein → Complete dungeon → Exit sets pendulum_discovered
+  ↓ Return to overworld → Scene 2 trigger (Vaelith, after vaelith_ember_vein)
+  ↓ Walk toward Ironmouth area → Scene 3 stub trigger
+    → Sets carradan_ambush_survived → Lira + Sable join
+  ↓ Continue walking → Scene 4 trigger (Dawn March dialogue)
+    → Sets opening_credits_seen
+  ↓ Walk to Roothollow → Scene 5 trigger → Torren joins
+  ↓ Walk to Maren's Refuge → Scene 6 trigger → Maren joins
+  ↓ Walk to Valdris Crown → Continue story
+```
+
+---
+
+## 3. Exploration Changes
+
+### _check_party_joining_flags() — Add Lira + Sable
+
+```gdscript
+func _check_party_joining_flags() -> void:
+    if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("lira"):
+        PartyState.add_member("lira", _get_party_avg_level())
+        flash_location_name("Lira joined the party!")
+    if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("sable"):
+        PartyState.add_member("sable", _get_party_avg_level())
+        flash_location_name("Sable joined the party!")
+    if EventFlags.get_flag("torren_joined") and not PartyState.has_member("torren"):
+        PartyState.add_member("torren", _get_party_avg_level())
+        flash_location_name("Torren joined the party!")
+    if EventFlags.get_flag("maren_warning") and not PartyState.has_member("maren"):
+        PartyState.add_member("maren", _get_party_avg_level())
+        flash_location_name("Maren joined the party!")
+```
+
+Both Lira and Sable join on the same flag (`carradan_ambush_survived`).
+
+### Ember Vein Exit Flag
+
+In `game/scenes/maps/dungeons/ember_vein_f4.tscn`, the exit transition
+(ExitToOverworld) needs a dialogue trigger that sets `pendulum_discovered`
+and `vaelith_ember_vein` flags after the boss is defeated.
+
+Since the Vein Guardian boss fight already sets `vaelith_ember_vein` via
+an existing boss trigger zone, we just need to verify the flag is set
+and add `pendulum_discovered` to the boss completion flow.
+
+---
+
+## 4. Overworld Triggers
+
+### Scene 2: Vaelith Encounter
+
+Add a dialogue trigger near the Ember Vein entrance on the overworld:
+- Position: near from_ember_vein marker (~848, 528)
+- `required_flag = "vaelith_ember_vein"`
+- `flag = "vaelith_scene_complete"` (one-shot)
+- `dialogue_scene_id = "scene_2_vaelith_encounter"`
+
+### Scene 3: Ironmouth Escape (Placeholder)
+
+Add a dialogue trigger between Ember Vein and the main overworld:
+- Position: ~(700, 500) — south of Ember Vein
+- `required_flag = "vaelith_scene_complete"`
+- `flag = "carradan_ambush_survived"`
+- `dialogue_scene_id = "scene_3_ironmouth_escape"`
+- This is a STUB — full Scene 3 with Ironmouth map is Phase B2
+
+### Scene 4: Dawn March
+
+Add a dialogue trigger between Ironmouth and Roothollow:
+- Position: ~(600, 480) — midway on the overworld
+- `required_flag = "carradan_ambush_survived"`
+- `flag = "opening_credits_seen"`
+- `dialogue_scene_id = "scene_4_dawn_march"`
+
+---
+
+## 5. Dialogue Data Files
+
+### scene_2_vaelith_encounter.json (NEW)
+
+Canonical text from script/act-i.md Scene 2. Key lines:
+- Vaelith: "If I wanted to stop you, I wouldn't have waited up here"
+- Vaelith: "What a fragile little thing it is to build hope around"
+- Vaelith calls Cael by name without introduction
+- Vaelith: "Do take care of yourself, Cael"
+
+### scene_3_ironmouth_escape.json (NEW — STUB)
+
+Abbreviated version of Scene 3 for B1. Key lines:
+- Lira: "Patrol passes in forty seconds. You came from the mine?"
+- Sable: "I was definitely not looting supplies"
+- Narrator: "Lira and Sable have joined the party"
+
+Full Scene 3 with Ironmouth map combat deferred to B2.
+
+### scene_4_dawn_march.json (NEW)
+
+Canonical text from script/act-i.md Scene 4. Key lines:
+- Cael: "Those miners... they just stopped"
+- Sable: "That thing in the satchel"
+- Lira: "Don't ask"
+- Title card reference (text only — visual credits deferred to B2)
+
+---
+
+## 6. Starting Equipment
+
+Add Lira and Sable to STARTING_EQUIPMENT in party_state.gd:
+
+```gdscript
+const STARTING_EQUIPMENT: Dictionary = {
+    "edren": {"weapon": "training_sword", "head": "", "body": "", "accessory": "", "crystal": ""},
+    "cael": {"weapon": "recruits_claymore", "head": "", "body": "", "accessory": "", "crystal": ""},
+    "lira": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
+    "sable": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
+}
+```
+
+Lira and Sable join without weapons (player equips them from inventory).
+
+---
+
+## 7. Test Plan
+
+### New tests (test_opening_sequence.gd)
+
+- `test_new_game_starts_with_two_members` — PartyState after new game has exactly Edren+Cael
+- `test_lira_joins_on_carradan_flag` — Setting carradan_ambush_survived adds Lira
+- `test_sable_joins_on_carradan_flag` — Same flag adds Sable
+- `test_lira_sable_join_together` — Both join on same flag, neither duplicated
+- `test_full_party_assembly_order` — Set all 4 flags in order, verify 6 members
+- `test_scene_2_dialogue_exists` — Dialogue file loads
+- `test_scene_3_dialogue_exists` — Dialogue file loads
+- `test_scene_4_dialogue_exists` — Dialogue file loads
+
+### Updated tests
+
+- `test_party_state.gd` — Verify Lira/Sable in STARTING_EQUIPMENT
+- `test_wilds_route.gd` — No changes needed (Torren/Maren flow unchanged)
+
+---
+
+## 8. File Map
+
+| File | Action | What Changes |
+|------|--------|-------------|
+| `game/scripts/core/exploration.gd` | MODIFY | Add Lira+Sable to _check_party_joining_flags |
+| `game/scripts/autoload/party_state.gd` | MODIFY | Add Lira+Sable to STARTING_EQUIPMENT |
+| `game/scenes/maps/overworld.tscn` | MODIFY | Add Scene 2, 3, 4 dialogue triggers |
+| `game/data/dialogue/scene_2_vaelith_encounter.json` | CREATE | Vaelith encounter dialogue |
+| `game/data/dialogue/scene_3_ironmouth_escape.json` | CREATE | Ironmouth escape stub dialogue |
+| `game/data/dialogue/scene_4_dawn_march.json` | CREATE | Dawn March dialogue |
+| `game/tests/test_opening_sequence.gd` | CREATE | Party assembly + dialogue tests |
+| `docs/analysis/game-dev-gaps.md` | MODIFY | Update gap 4.4 Phase B |
+
+---
+
+## 9. Remaining After B1 (Phase B2)
+
+Explicitly tracked for future work:
+
+- [ ] Ironmouth outpost map (.tscn with NPCs, Forgewright crates)
+- [ ] Ember Vein F3 (Ancient Ruin floor with geometric puzzles)
+- [ ] Full Scene 1 tutorial dialogue (all 1a-1e beats with combat)
+- [ ] Full Scene 3 Ironmouth escape (combat sequence with soldiers)
+- [ ] Opening credits visual sequence (title card, character names)
+- [ ] Dawn March forward-only walk mechanics
+- [ ] Arcanite gear preview (Edren's enhanced equipment that breaks)
+- [ ] Change new game start location from overworld to Ember Vein F1
+- [ ] Cael hidden stat spike (Pallor's first touch)

--- a/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
+++ b/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
@@ -192,9 +192,9 @@ Lira and Sable join without weapons (player equips them from inventory).
 | `game/scripts/core/exploration.gd` | MODIFY | Add Lira+Sable to _check_party_joining_flags |
 | `game/scripts/autoload/party_state.gd` | MODIFY | Add Lira+Sable to STARTING_EQUIPMENT |
 | `game/scenes/maps/overworld.tscn` | MODIFY | Add Scene 2, 3, 4 dialogue triggers |
-| `game/data/dialogue/scene_2_vaelith_encounter.json` | CREATE | Vaelith encounter dialogue |
-| `game/data/dialogue/scene_3_ironmouth_escape.json` | CREATE | Ironmouth escape stub dialogue |
-| `game/data/dialogue/scene_4_dawn_march.json` | CREATE | Dawn March dialogue |
+| `game/data/dialogue/vaelith_ember_vein.json` | EXISTING | Vaelith encounter dialogue (gap 1.8) |
+| `game/data/dialogue/ironmouth_escape.json` | EXISTING | Ironmouth escape dialogue (gap 1.8) |
+| `game/data/dialogue/dawn_march.json` | EXISTING | Dawn March dialogue (gap 1.8) |
 | `game/tests/test_opening_sequence.gd` | CREATE | Party assembly + dialogue tests |
 | `docs/analysis/game-dev-gaps.md` | MODIFY | Update gap 4.4 Phase B |
 

--- a/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
+++ b/docs/superpowers/specs/2026-04-09-opening-sequence-b1-design.md
@@ -99,7 +99,7 @@ Add a dialogue trigger near the Ember Vein entrance on the overworld:
 - Position: near from_ember_vein marker (~848, 528)
 - `required_flag = "vaelith_ember_vein"`
 - `flag = "vaelith_scene_complete"` (one-shot)
-- `dialogue_scene_id = "scene_2_vaelith_encounter"`
+- `dialogue_scene_id = "vaelith_ember_vein"`
 
 ### Scene 3: Ironmouth Escape (Placeholder)
 
@@ -107,7 +107,7 @@ Add a dialogue trigger between Ember Vein and the main overworld:
 - Position: ~(700, 500) — south of Ember Vein
 - `required_flag = "vaelith_scene_complete"`
 - `flag = "carradan_ambush_survived"`
-- `dialogue_scene_id = "scene_3_ironmouth_escape"`
+- `dialogue_scene_id = "ironmouth_escape"`
 - This is a STUB — full Scene 3 with Ironmouth map is Phase B2
 
 ### Scene 4: Dawn March
@@ -116,36 +116,35 @@ Add a dialogue trigger between Ironmouth and Roothollow:
 - Position: ~(600, 480) — midway on the overworld
 - `required_flag = "carradan_ambush_survived"`
 - `flag = "opening_credits_seen"`
-- `dialogue_scene_id = "scene_4_dawn_march"`
+- `dialogue_scene_id = "dawn_march"`
 
 ---
 
 ## 5. Dialogue Data Files
 
-### scene_2_vaelith_encounter.json (NEW)
+Uses existing dialogue files from gap 1.8 (dialogue parser):
 
-Canonical text from script/act-i.md Scene 2. Key lines:
+### vaelith_ember_vein.json (EXISTING)
+
+Canonical text from script/act-i.md Scene 2 (16 entries). Key lines:
 - Vaelith: "If I wanted to stop you, I wouldn't have waited up here"
 - Vaelith: "What a fragile little thing it is to build hope around"
 - Vaelith calls Cael by name without introduction
 - Vaelith: "Do take care of yourself, Cael"
 
-### scene_3_ironmouth_escape.json (NEW — STUB)
+### ironmouth_escape.json (EXISTING)
 
-Abbreviated version of Scene 3 for B1. Key lines:
+Full Scene 3 dialogue (15 entries). Key lines:
 - Lira: "Patrol passes in forty seconds. You came from the mine?"
 - Sable: "I was definitely not looting supplies"
-- Narrator: "Lira and Sable have joined the party"
+- Party joins handled by flag system, not dialogue
 
-Full Scene 3 with Ironmouth map combat deferred to B2.
+### dawn_march.json (EXISTING)
 
-### scene_4_dawn_march.json (NEW)
-
-Canonical text from script/act-i.md Scene 4. Key lines:
+Scene 4 walk dialogue (12 entries) with front/back group interleaving:
 - Cael: "Those miners... they just stopped"
 - Sable: "That thing in the satchel"
 - Lira: "Don't ask"
-- Title card reference (text only — visual credits deferred to B2)
 
 ---
 

--- a/game/scenes/maps/overworld.tscn
+++ b/game/scenes/maps/overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=3]
+[gd_scene load_steps=9 format=3]
 
 [ext_resource type="TileSet" path="res://assets/tilesets/placeholder_dungeon.tres" id="1_tileset"]
 
@@ -12,6 +12,15 @@ size = Vector2(48, 48)
 size = Vector2(48, 48)
 
 [sub_resource type="RectangleShape2D" id="Shape_marens"]
+size = Vector2(48, 48)
+
+[sub_resource type="RectangleShape2D" id="Shape_scene2"]
+size = Vector2(48, 48)
+
+[sub_resource type="RectangleShape2D" id="Shape_scene3"]
+size = Vector2(48, 48)
+
+[sub_resource type="RectangleShape2D" id="Shape_scene4"]
 size = Vector2(48, 48)
 
 [node name="Overworld" type="Node2D"]
@@ -91,6 +100,45 @@ position = Vector2(448, 448)
 [node name="from_marens_refuge" type="Marker2D" parent="."]
 position = Vector2(224, 464)
 
+[node name="Scene2Trigger" type="Area2D" parent="Entities"]
+position = Vector2(816, 528)
+collision_layer = 0
+collision_mask = 2
+monitoring = true
+monitorable = false
+metadata/flag = "vaelith_scene_complete"
+metadata/required_flag = "vaelith_ember_vein"
+metadata/dialogue_scene_id = "vaelith_ember_vein"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Entities/Scene2Trigger"]
+shape = SubResource("Shape_scene2")
+
+[node name="Scene3Trigger" type="Area2D" parent="Entities"]
+position = Vector2(688, 496)
+collision_layer = 0
+collision_mask = 2
+monitoring = true
+monitorable = false
+metadata/flag = "carradan_ambush_survived"
+metadata/required_flag = "vaelith_scene_complete"
+metadata/dialogue_scene_id = "ironmouth_escape"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Entities/Scene3Trigger"]
+shape = SubResource("Shape_scene3")
+
+[node name="Scene4Trigger" type="Area2D" parent="Entities"]
+position = Vector2(576, 480)
+collision_layer = 0
+collision_mask = 2
+monitoring = true
+monitorable = false
+metadata/flag = "opening_credits_seen"
+metadata/required_flag = "carradan_ambush_survived"
+metadata/dialogue_scene_id = "dawn_march"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Entities/Scene4Trigger"]
+shape = SubResource("Shape_scene4")
+
 [node name="LabelValdris" type="Label" parent="."]
 offset_left = 48
 offset_top = 56
@@ -121,4 +169,12 @@ offset_top = 472
 offset_right = 260
 offset_bottom = 488
 text = "Maren's Refuge"
+horizontal_alignment = 1
+
+[node name="LabelIronmouth" type="Label" parent="."]
+offset_left = 648
+offset_top = 472
+offset_right = 760
+offset_bottom = 488
+text = "Ironmouth"
 horizontal_alignment = 1

--- a/game/scenes/maps/overworld.tscn
+++ b/game/scenes/maps/overworld.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3]
+[gd_scene load_steps=8 format=3]
 
 [ext_resource type="TileSet" path="res://assets/tilesets/placeholder_dungeon.tres" id="1_tileset"]
 

--- a/game/scripts/autoload/party_state.gd
+++ b/game/scripts/autoload/party_state.gd
@@ -17,6 +17,8 @@ const CLASS_TITLES: Dictionary = {
 const STARTING_EQUIPMENT: Dictionary = {
 	"edren": {"weapon": "training_sword", "head": "", "body": "", "accessory": "", "crystal": ""},
 	"cael": {"weapon": "recruits_claymore", "head": "", "body": "", "accessory": "", "crystal": ""},
+	"lira": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
+	"sable": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
 }
 
 const STARTING_CONSUMABLES: Dictionary = {

--- a/game/scripts/autoload/party_state.gd
+++ b/game/scripts/autoload/party_state.gd
@@ -19,6 +19,8 @@ const STARTING_EQUIPMENT: Dictionary = {
 	"cael": {"weapon": "recruits_claymore", "head": "", "body": "", "accessory": "", "crystal": ""},
 	"lira": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
 	"sable": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
+	"torren": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
+	"maren": {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""},
 }
 
 const STARTING_CONSUMABLES: Dictionary = {

--- a/game/scripts/core/exploration.gd
+++ b/game/scripts/core/exploration.gd
@@ -382,6 +382,12 @@ func _on_dialogue_closed_check_party(_state: Variant) -> void:
 
 
 func _check_party_joining_flags() -> void:
+	if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("lira"):
+		PartyState.add_member("lira", _get_party_avg_level())
+		flash_location_name("Lira joined the party!")
+	if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("sable"):
+		PartyState.add_member("sable", _get_party_avg_level())
+		flash_location_name("Sable joined the party!")
 	if EventFlags.get_flag("torren_joined") and not PartyState.has_member("torren"):
 		PartyState.add_member("torren", _get_party_avg_level())
 		flash_location_name("Torren joined the party!")

--- a/game/scripts/core/exploration.gd
+++ b/game/scripts/core/exploration.gd
@@ -382,12 +382,21 @@ func _on_dialogue_closed_check_party(_state: Variant) -> void:
 
 
 func _check_party_joining_flags() -> void:
-	if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("lira"):
-		PartyState.add_member("lira", _get_party_avg_level())
-		flash_location_name("Lira joined the party!")
-	if EventFlags.get_flag("carradan_ambush_survived") and not PartyState.has_member("sable"):
-		PartyState.add_member("sable", _get_party_avg_level())
-		flash_location_name("Sable joined the party!")
+	if EventFlags.get_flag("carradan_ambush_survived"):
+		var added_lira: bool = false
+		var added_sable: bool = false
+		if not PartyState.has_member("lira"):
+			PartyState.add_member("lira", _get_party_avg_level())
+			added_lira = true
+		if not PartyState.has_member("sable"):
+			PartyState.add_member("sable", _get_party_avg_level())
+			added_sable = true
+		if added_lira and added_sable:
+			flash_location_name("Lira and Sable joined the party!")
+		elif added_lira:
+			flash_location_name("Lira joined the party!")
+		elif added_sable:
+			flash_location_name("Sable joined the party!")
 	if EventFlags.get_flag("torren_joined") and not PartyState.has_member("torren"):
 		PartyState.add_member("torren", _get_party_avg_level())
 		flash_location_name("Torren joined the party!")

--- a/game/scripts/core/exploration.gd
+++ b/game/scripts/core/exploration.gd
@@ -377,7 +377,9 @@ func _on_dialogue_trigger_entered(body: Node2D, area: Area2D) -> void:
 			)
 
 
-func _on_dialogue_closed_check_party(_state: Variant) -> void:
+func _on_dialogue_closed_check_party(state: GameManager.OverlayState) -> void:
+	if state != GameManager.OverlayState.NONE:
+		return
 	_check_party_joining_flags()
 
 

--- a/game/tests/test_opening_sequence.gd
+++ b/game/tests/test_opening_sequence.gd
@@ -181,9 +181,9 @@ func test_overworld_has_scene4_trigger() -> void:
 
 func test_scene_triggers_in_story_order() -> void:
 	var overworld: Node = _load_overworld()
-	var s2: Node = overworld.get_node_or_null("Entities/Scene2Trigger")
-	var s3: Node = overworld.get_node_or_null("Entities/Scene3Trigger")
-	var s4: Node = overworld.get_node_or_null("Entities/Scene4Trigger")
+	var s2: Node2D = overworld.get_node_or_null("Entities/Scene2Trigger") as Node2D
+	var s3: Node2D = overworld.get_node_or_null("Entities/Scene3Trigger") as Node2D
+	var s4: Node2D = overworld.get_node_or_null("Entities/Scene4Trigger") as Node2D
 	assert_not_null(s2, "scene 2 trigger should exist")
 	assert_not_null(s3, "scene 3 trigger should exist")
 	assert_not_null(s4, "scene 4 trigger should exist")

--- a/game/tests/test_opening_sequence.gd
+++ b/game/tests/test_opening_sequence.gd
@@ -90,18 +90,20 @@ func test_fifth_member_goes_to_reserve() -> void:
 
 func test_lira_has_starting_equipment_entry() -> void:
 	var text: String = _read_file("res://scripts/autoload/party_state.gd")
-	assert_true(
-		text.contains('"lira"') and text.contains("STARTING_EQUIPMENT"),
-		"party_state should have lira in STARTING_EQUIPMENT",
-	)
+	var marker: String = "STARTING_EQUIPMENT"
+	var idx: int = text.find(marker)
+	assert_true(idx >= 0, "STARTING_EQUIPMENT should exist")
+	var block: String = text.substr(idx, 500)
+	assert_true(block.contains('"lira"'), "lira should be in STARTING_EQUIPMENT block")
 
 
 func test_sable_has_starting_equipment_entry() -> void:
 	var text: String = _read_file("res://scripts/autoload/party_state.gd")
-	assert_true(
-		text.contains('"sable"') and text.contains("STARTING_EQUIPMENT"),
-		"party_state should have sable in STARTING_EQUIPMENT",
-	)
+	var marker: String = "STARTING_EQUIPMENT"
+	var idx: int = text.find(marker)
+	assert_true(idx >= 0, "STARTING_EQUIPMENT should exist")
+	var block: String = text.substr(idx, 500)
+	assert_true(block.contains('"sable"'), "sable should be in STARTING_EQUIPMENT block")
 
 
 # --- Dialogue Data ---

--- a/game/tests/test_opening_sequence.gd
+++ b/game/tests/test_opening_sequence.gd
@@ -1,0 +1,210 @@
+extends GutTest
+## Tests for the Opening Sequence (Phase B1) — party assembly flow,
+## dialogue data existence, and overworld trigger wiring.
+
+
+func before_each() -> void:
+	DataManager.clear_cache()
+	EventFlags.clear_all()
+
+
+func after_each() -> void:
+	DataManager.clear_cache()
+	EventFlags.clear_all()
+
+
+# --- Party Assembly ---
+
+
+func test_new_game_starts_with_two_members() -> void:
+	PartyState.initialize_new_game()
+	assert_eq(PartyState.members.size(), 2, "new game should start with 2 members")
+	assert_true(PartyState.has_member("edren"), "edren should be in starting party")
+	assert_true(PartyState.has_member("cael"), "cael should be in starting party")
+	assert_false(PartyState.has_member("lira"), "lira should NOT be in starting party")
+	assert_false(PartyState.has_member("sable"), "sable should NOT be in starting party")
+	assert_false(PartyState.has_member("torren"), "torren should NOT be in starting party")
+	assert_false(PartyState.has_member("maren"), "maren should NOT be in starting party")
+
+
+func test_lira_joins_on_carradan_flag() -> void:
+	PartyState.initialize_new_game()
+	PartyState.add_member("lira", 1)
+	assert_true(PartyState.has_member("lira"), "lira should join after add_member")
+
+
+func test_sable_joins_on_carradan_flag() -> void:
+	PartyState.initialize_new_game()
+	PartyState.add_member("sable", 1)
+	assert_true(PartyState.has_member("sable"), "sable should join after add_member")
+
+
+func test_lira_sable_join_together_no_duplicates() -> void:
+	PartyState.initialize_new_game()
+	PartyState.add_member("lira", 1)
+	PartyState.add_member("sable", 1)
+	PartyState.add_member("lira", 1)
+	PartyState.add_member("sable", 1)
+	var lira_count: int = 0
+	var sable_count: int = 0
+	for m: Dictionary in PartyState.members:
+		if m.get("character_id", "") == "lira":
+			lira_count += 1
+		elif m.get("character_id", "") == "sable":
+			sable_count += 1
+	assert_eq(lira_count, 1, "lira should appear exactly once")
+	assert_eq(sable_count, 1, "sable should appear exactly once")
+
+
+func test_full_party_assembly_order() -> void:
+	PartyState.initialize_new_game()
+	assert_eq(PartyState.members.size(), 2, "start with 2")
+	PartyState.add_member("lira", 1)
+	PartyState.add_member("sable", 1)
+	assert_eq(PartyState.members.size(), 4, "4 after lira+sable")
+	PartyState.add_member("torren", 1)
+	assert_eq(PartyState.members.size(), 5, "5 after torren")
+	PartyState.add_member("maren", 1)
+	assert_eq(PartyState.members.size(), 6, "6 after maren — full party")
+
+
+func test_lira_sable_go_to_active_party() -> void:
+	PartyState.initialize_new_game()
+	PartyState.add_member("lira", 1)
+	PartyState.add_member("sable", 1)
+	var active: Array = PartyState.formation.get("active", [])
+	assert_eq(active.size(), 4, "all 4 should be active (Edren, Cael, Lira, Sable)")
+
+
+func test_fifth_member_goes_to_reserve() -> void:
+	PartyState.initialize_new_game()
+	PartyState.add_member("lira", 1)
+	PartyState.add_member("sable", 1)
+	PartyState.add_member("torren", 1)
+	var reserve: Array = PartyState.formation.get("reserve", [])
+	assert_eq(reserve.size(), 1, "5th member should go to reserve")
+
+
+# --- Starting Equipment ---
+
+
+func test_lira_has_starting_equipment_entry() -> void:
+	var text: String = _read_file("res://scripts/autoload/party_state.gd")
+	assert_true(
+		text.contains('"lira"') and text.contains("STARTING_EQUIPMENT"),
+		"party_state should have lira in STARTING_EQUIPMENT",
+	)
+
+
+func test_sable_has_starting_equipment_entry() -> void:
+	var text: String = _read_file("res://scripts/autoload/party_state.gd")
+	assert_true(
+		text.contains('"sable"') and text.contains("STARTING_EQUIPMENT"),
+		"party_state should have sable in STARTING_EQUIPMENT",
+	)
+
+
+# --- Dialogue Data ---
+
+
+func test_scene_2_dialogue_exists() -> void:
+	var data: Dictionary = DataManager.load_dialogue("vaelith_ember_vein")
+	assert_false(data.is_empty(), "vaelith_ember_vein dialogue should load")
+	var entries: Array = data.get("entries", [])
+	assert_gt(entries.size(), 0, "scene 2 should have entries")
+
+
+func test_scene_3_dialogue_exists() -> void:
+	var data: Dictionary = DataManager.load_dialogue("ironmouth_escape")
+	assert_false(data.is_empty(), "ironmouth_escape dialogue should load")
+	var entries: Array = data.get("entries", [])
+	assert_gt(entries.size(), 0, "scene 3 should have entries")
+
+
+func test_scene_4_dialogue_exists() -> void:
+	var data: Dictionary = DataManager.load_dialogue("dawn_march")
+	assert_false(data.is_empty(), "dawn_march dialogue should load")
+	var entries: Array = data.get("entries", [])
+	assert_gt(entries.size(), 0, "scene 4 should have entries")
+
+
+# --- Overworld Trigger Wiring ---
+
+
+func test_overworld_has_scene2_trigger() -> void:
+	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	assert_true(
+		text.contains("vaelith_ember_vein"),
+		"overworld should have Scene 2 dialogue trigger",
+	)
+	assert_true(
+		text.contains("vaelith_ember_vein") and text.contains("required_flag"),
+		"Scene 2 trigger should require vaelith_ember_vein flag",
+	)
+
+
+func test_overworld_has_scene3_trigger() -> void:
+	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	assert_true(
+		text.contains("ironmouth_escape"),
+		"overworld should have Scene 3 dialogue trigger",
+	)
+	assert_true(
+		text.contains("carradan_ambush_survived"),
+		"Scene 3 trigger should set carradan_ambush_survived flag",
+	)
+
+
+func test_overworld_has_scene4_trigger() -> void:
+	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	assert_true(
+		text.contains("dawn_march"),
+		"overworld should have Scene 4 dialogue trigger",
+	)
+	assert_true(
+		text.contains("opening_credits_seen"),
+		"Scene 4 trigger should set opening_credits_seen flag",
+	)
+
+
+func test_scene_triggers_in_story_order() -> void:
+	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	var s2_pos: int = text.find("vaelith_ember_vein")
+	var s3_pos: int = text.find("ironmouth_escape")
+	var s4_pos: int = text.find("dawn_march")
+	assert_gt(s2_pos, 0, "scene 2 trigger should exist")
+	assert_gt(s3_pos, s2_pos, "scene 3 trigger should appear after scene 2")
+	assert_gt(s4_pos, s3_pos, "scene 4 trigger should appear after scene 3")
+
+
+# --- Party Join Flag Wiring ---
+
+
+func test_exploration_checks_carradan_flag() -> void:
+	var text: String = _read_file("res://scripts/core/exploration.gd")
+	assert_true(
+		text.contains("carradan_ambush_survived"),
+		"exploration should check carradan_ambush_survived flag for party joins",
+	)
+	assert_true(
+		text.contains('add_member("lira"'),
+		"exploration should add lira on carradan flag",
+	)
+	assert_true(
+		text.contains('add_member("sable"'),
+		"exploration should add sable on carradan flag",
+	)
+
+
+# --- Helper ---
+
+
+func _read_file(path: String) -> String:
+	if not FileAccess.file_exists(path):
+		return ""
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var text: String = file.get_as_text()
+	file.close()
+	return text

--- a/game/tests/test_opening_sequence.gd
+++ b/game/tests/test_opening_sequence.gd
@@ -135,37 +135,46 @@ func test_scene_4_dialogue_exists() -> void:
 
 func test_overworld_has_scene2_trigger() -> void:
 	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	var idx: int = text.find("Scene2Trigger")
+	assert_gt(idx, 0, "overworld should have Scene2Trigger node")
+	var block: String = text.substr(idx, 300)
 	assert_true(
-		text.contains("vaelith_ember_vein"),
-		"overworld should have Scene 2 dialogue trigger",
+		block.contains('dialogue_scene_id = "vaelith_ember_vein"'),
+		"Scene2Trigger should reference vaelith_ember_vein dialogue",
 	)
 	assert_true(
-		text.contains("vaelith_ember_vein") and text.contains("required_flag"),
-		"Scene 2 trigger should require vaelith_ember_vein flag",
+		block.contains('required_flag = "vaelith_ember_vein"'),
+		"Scene2Trigger should require vaelith_ember_vein flag",
 	)
 
 
 func test_overworld_has_scene3_trigger() -> void:
 	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	var idx: int = text.find("Scene3Trigger")
+	assert_gt(idx, 0, "overworld should have Scene3Trigger node")
+	var block: String = text.substr(idx, 300)
 	assert_true(
-		text.contains("ironmouth_escape"),
-		"overworld should have Scene 3 dialogue trigger",
+		block.contains('flag = "carradan_ambush_survived"'),
+		"Scene3Trigger should set carradan_ambush_survived flag",
 	)
 	assert_true(
-		text.contains("carradan_ambush_survived"),
-		"Scene 3 trigger should set carradan_ambush_survived flag",
+		block.contains('dialogue_scene_id = "ironmouth_escape"'),
+		"Scene3Trigger should reference ironmouth_escape dialogue",
 	)
 
 
 func test_overworld_has_scene4_trigger() -> void:
 	var text: String = _read_file("res://scenes/maps/overworld.tscn")
+	var idx: int = text.find("Scene4Trigger")
+	assert_gt(idx, 0, "overworld should have Scene4Trigger node")
+	var block: String = text.substr(idx, 300)
 	assert_true(
-		text.contains("dawn_march"),
-		"overworld should have Scene 4 dialogue trigger",
+		block.contains('flag = "opening_credits_seen"'),
+		"Scene4Trigger should set opening_credits_seen flag",
 	)
 	assert_true(
-		text.contains("opening_credits_seen"),
-		"Scene 4 trigger should set opening_credits_seen flag",
+		block.contains('dialogue_scene_id = "dawn_march"'),
+		"Scene4Trigger should reference dawn_march dialogue",
 	)
 
 

--- a/game/tests/test_opening_sequence.gd
+++ b/game/tests/test_opening_sequence.gd
@@ -28,16 +28,14 @@ func test_new_game_starts_with_two_members() -> void:
 	assert_false(PartyState.has_member("maren"), "maren should NOT be in starting party")
 
 
-func test_lira_joins_on_carradan_flag() -> void:
-	PartyState.initialize_new_game()
+func test_lira_can_be_added_to_party() -> void:
 	PartyState.add_member("lira", 1)
-	assert_true(PartyState.has_member("lira"), "lira should join after add_member")
+	assert_true(PartyState.has_member("lira"), "lira should be present after add_member")
 
 
-func test_sable_joins_on_carradan_flag() -> void:
-	PartyState.initialize_new_game()
+func test_sable_can_be_added_to_party() -> void:
 	PartyState.add_member("sable", 1)
-	assert_true(PartyState.has_member("sable"), "sable should join after add_member")
+	assert_true(PartyState.has_member("sable"), "sable should be present after add_member")
 
 
 func test_lira_sable_join_together_no_duplicates() -> void:
@@ -90,21 +88,17 @@ func test_fifth_member_goes_to_reserve() -> void:
 
 
 func test_lira_has_starting_equipment_entry() -> void:
-	var text: String = _read_file("res://scripts/autoload/party_state.gd")
-	var marker: String = "STARTING_EQUIPMENT"
-	var idx: int = text.find(marker)
-	assert_true(idx >= 0, "STARTING_EQUIPMENT should exist")
-	var block: String = text.substr(idx, 500)
-	assert_true(block.contains('"lira"'), "lira should be in STARTING_EQUIPMENT block")
+	assert_true(
+		PartyState.STARTING_EQUIPMENT.has("lira"),
+		"lira should be in STARTING_EQUIPMENT",
+	)
 
 
 func test_sable_has_starting_equipment_entry() -> void:
-	var text: String = _read_file("res://scripts/autoload/party_state.gd")
-	var marker: String = "STARTING_EQUIPMENT"
-	var idx: int = text.find(marker)
-	assert_true(idx >= 0, "STARTING_EQUIPMENT should exist")
-	var block: String = text.substr(idx, 500)
-	assert_true(block.contains('"sable"'), "sable should be in STARTING_EQUIPMENT block")
+	assert_true(
+		PartyState.STARTING_EQUIPMENT.has("sable"),
+		"sable should be in STARTING_EQUIPMENT",
+	)
 
 
 # --- Dialogue Data ---
@@ -135,58 +129,68 @@ func test_scene_4_dialogue_exists() -> void:
 
 
 func test_overworld_has_scene2_trigger() -> void:
-	var text: String = _read_file("res://scenes/maps/overworld.tscn")
-	var idx: int = text.find("Scene2Trigger")
-	assert_gt(idx, 0, "overworld should have Scene2Trigger node")
-	var block: String = text.substr(idx, 300)
-	assert_true(
-		block.contains('dialogue_scene_id = "vaelith_ember_vein"'),
+	var overworld: Node = _load_overworld()
+	var trigger: Node = overworld.get_node_or_null("Entities/Scene2Trigger")
+	assert_not_null(trigger, "overworld should have Entities/Scene2Trigger")
+	assert_eq(
+		str(trigger.get_meta("dialogue_scene_id", "")),
+		"vaelith_ember_vein",
 		"Scene2Trigger should reference vaelith_ember_vein dialogue",
 	)
-	assert_true(
-		block.contains('required_flag = "vaelith_ember_vein"'),
+	assert_eq(
+		str(trigger.get_meta("required_flag", "")),
+		"vaelith_ember_vein",
 		"Scene2Trigger should require vaelith_ember_vein flag",
 	)
+	overworld.queue_free()
 
 
 func test_overworld_has_scene3_trigger() -> void:
-	var text: String = _read_file("res://scenes/maps/overworld.tscn")
-	var idx: int = text.find("Scene3Trigger")
-	assert_gt(idx, 0, "overworld should have Scene3Trigger node")
-	var block: String = text.substr(idx, 300)
-	assert_true(
-		block.contains('flag = "carradan_ambush_survived"'),
+	var overworld: Node = _load_overworld()
+	var trigger: Node = overworld.get_node_or_null("Entities/Scene3Trigger")
+	assert_not_null(trigger, "overworld should have Entities/Scene3Trigger")
+	assert_eq(
+		str(trigger.get_meta("flag", "")),
+		"carradan_ambush_survived",
 		"Scene3Trigger should set carradan_ambush_survived flag",
 	)
-	assert_true(
-		block.contains('dialogue_scene_id = "ironmouth_escape"'),
+	assert_eq(
+		str(trigger.get_meta("dialogue_scene_id", "")),
+		"ironmouth_escape",
 		"Scene3Trigger should reference ironmouth_escape dialogue",
 	)
+	overworld.queue_free()
 
 
 func test_overworld_has_scene4_trigger() -> void:
-	var text: String = _read_file("res://scenes/maps/overworld.tscn")
-	var idx: int = text.find("Scene4Trigger")
-	assert_gt(idx, 0, "overworld should have Scene4Trigger node")
-	var block: String = text.substr(idx, 300)
-	assert_true(
-		block.contains('flag = "opening_credits_seen"'),
+	var overworld: Node = _load_overworld()
+	var trigger: Node = overworld.get_node_or_null("Entities/Scene4Trigger")
+	assert_not_null(trigger, "overworld should have Entities/Scene4Trigger")
+	assert_eq(
+		str(trigger.get_meta("flag", "")),
+		"opening_credits_seen",
 		"Scene4Trigger should set opening_credits_seen flag",
 	)
-	assert_true(
-		block.contains('dialogue_scene_id = "dawn_march"'),
+	assert_eq(
+		str(trigger.get_meta("dialogue_scene_id", "")),
+		"dawn_march",
 		"Scene4Trigger should reference dawn_march dialogue",
 	)
+	overworld.queue_free()
 
 
 func test_scene_triggers_in_story_order() -> void:
-	var text: String = _read_file("res://scenes/maps/overworld.tscn")
-	var s2_pos: int = text.find("vaelith_ember_vein")
-	var s3_pos: int = text.find("ironmouth_escape")
-	var s4_pos: int = text.find("dawn_march")
-	assert_gt(s2_pos, 0, "scene 2 trigger should exist")
-	assert_gt(s3_pos, s2_pos, "scene 3 trigger should appear after scene 2")
-	assert_gt(s4_pos, s3_pos, "scene 4 trigger should appear after scene 3")
+	var overworld: Node = _load_overworld()
+	var s2: Node = overworld.get_node_or_null("Entities/Scene2Trigger")
+	var s3: Node = overworld.get_node_or_null("Entities/Scene3Trigger")
+	var s4: Node = overworld.get_node_or_null("Entities/Scene4Trigger")
+	assert_not_null(s2, "scene 2 trigger should exist")
+	assert_not_null(s3, "scene 3 trigger should exist")
+	assert_not_null(s4, "scene 4 trigger should exist")
+	# Triggers should progress from east (Ember Vein) to west (Roothollow)
+	assert_gt(s2.position.x, s3.position.x, "scene 2 should be east of scene 3")
+	assert_gt(s3.position.x, s4.position.x, "scene 3 should be east of scene 4")
+	overworld.queue_free()
 
 
 # --- Party Join Flag Wiring ---
@@ -208,7 +212,12 @@ func test_exploration_checks_carradan_flag() -> void:
 	)
 
 
-# --- Helper ---
+# --- Helpers ---
+
+
+func _load_overworld() -> Node:
+	var scene: PackedScene = load("res://scenes/maps/overworld.tscn")
+	return scene.instantiate()
 
 
 func _read_file(path: String) -> String:

--- a/game/tests/test_opening_sequence.gd
+++ b/game/tests/test_opening_sequence.gd
@@ -4,6 +4,7 @@ extends GutTest
 
 
 func before_each() -> void:
+	PartyState.initialize_new_game()
 	DataManager.clear_cache()
 	EventFlags.clear_all()
 


### PR DESCRIPTION
## Summary
- Wire correct party assembly flow: New Game starts with Edren+Cael only
- Lira and Sable join via carradan_ambush_survived flag (same pattern as Torren/Maren)
- Add Scene 2 (Vaelith encounter), Scene 3 (Ironmouth escape stub), Scene 4 (Dawn March) dialogue triggers on overworld
- Use existing dialogue data files from gap 1.8: vaelith_ember_vein.json, ironmouth_escape.json, dawn_march.json
- Add Lira+Sable to STARTING_EQUIPMENT (empty — player equips from inventory)
- Add Ironmouth location label to overworld
- Gap 4.4 Phase B1 COMPLETE, Phase B2 explicitly tracked with full remaining checklist

### Party Assembly Flow (After B1)
```
New Game (Edren+Cael) -> Ember Vein -> Scene 2 (Vaelith) ->
Scene 3 (Lira+Sable join) -> Scene 4 (Dawn March) ->
Roothollow (Torren) -> Maren's Refuge (Maren) -> Valdris Crown
```

### What Remains (Phase B2 — NOT STARTED)
- Ironmouth outpost map
- Ember Vein F3 (Ancient Ruin floor with puzzles)
- Full Scene 1 tutorial dialogue (all 1a-1e beats)
- Full Scene 3 Ironmouth escape (combat with soldiers)
- Opening credits visual sequence
- Dawn March forward-only walk mechanics
- Arcanite gear preview
- Change new game start to Ember Vein F1

## Test plan
- [x] Pre-commit hooks pass (gdlint, gdformat, JSON validation)
- [x] Pre-push quality gates pass (ID uniqueness, stale counts, scene refs, GUT tests)
- [x] 422 GUT tests passing across 25 test files (17 new in test_opening_sequence.gd)
- [x] Party assembly: new game 2 members, Lira+Sable on flag, full 6-member assembly
- [x] Dialogue data: all 3 scene files load with entries
- [x] Overworld triggers: Scene 2/3/4 wired with required_flag gating in story order
- [x] No duplicate party members on repeated flag checks

Generated with [Claude Code](https://claude.ai/code)
