### PR TITLE
chore(deps): update dependencies, Godot 4.7, and tooling

### DIFF
--- a/.claude/skills/godot-review/references/verification-checklists.md
+++ b/.claude/skills/godot-review/references/verification-checklists.md
@@ -456,3 +456,24 @@ cannot point to the exact line that handles the case, it's a bug.
 - [ ] Flag names match events.md
 - [ ] Animation IDs match dialogue-system.md catalog (14 animations + clear)
 - [ ] Accessibility features match accessibility.md
+
+## 10. Vendored Dependencies (from Copilot PR #153 gap analysis)
+
+When a PR adds or updates a third-party addon under `game/addons/` (e.g.
+the GUT testing framework), the review scope changes — we do NOT audit
+library internals as if they were authored code.
+
+- [ ] Verify the vendored addon matches its upstream release byte-for-byte
+      (`diff -rq <release>/addons/<name> game/addons/<name>` is empty). The
+      copy must be pristine, not a local fork.
+- [ ] Confirm `plugin.cfg` `version=` matches the intended upstream tag.
+- [ ] Scope OUT library internals from review findings. Copilot reviews the
+      full diff and WILL flag bugs/typos inside vendored files — these are
+      pre-existing upstream issues, not introduced by the PR.
+- [ ] Disposition for any Copilot finding on a vendored file: **keep
+      pristine, report upstream** (file an issue at the addon's repo). Do
+      NOT patch the vendored copy — a local fork is silently lost on the
+      next dependency bump and complicates future updates.
+- [ ] The only authored-code concern is *how the project consumes* the
+      addon (CI invocation, autoload wiring, version pins) — review that,
+      not the library's own source.

--- a/.claude/skills/pr-review-response/references/copilot-gap-taxonomy.md
+++ b/.claude/skills/pr-review-response/references/copilot-gap-taxonomy.md
@@ -456,3 +456,33 @@ from PR #105: 32 new checklist items across 6 Copilot rounds.
 **Outcome:** No new checklist items. First round where all Copilot
 comments were false positives. Cumulative from PR #105: 32 checklist
 items across 7 rounds. Comments converging toward zero real issues.
+
+### PR #153 (2026-06-27) — 7 Copilot comments, 0 authored-code gaps, 1 process note
+
+**Context:** Dependency/tooling PR — Godot 4.6.2 → 4.7, GUT addon
+9.6.0 → 9.7.0, pnpm/commitlint bumps, `actions/checkout` v4 → v6.
+
+**All 7 comments landed on vendored upstream GUT 9.7.0 code**
+(`game/addons/gut/**`), verified byte-for-byte identical to the
+official bitwes/Gut v9.7.0 release:
+- check_for_update.gd: double `_mouse_down` assignment (bool then float)
+- update_detector.gd: `fetch_remote_file()` hang-on-failure; objects
+  used as dict keys; "lastest" typo
+- gut_plugin.gd: `_exit_tree()` unconditional `queue_free()` null deref
+- method_maker.gd: abstract-method template depends on `__gutdbl`
+- gut_cmdln.gd: `Laoder` variable typo
+
+**New pattern identified:** Vendored dependency review scope. Copilot
+reviews the full diff including third-party addon source; our
+godot-review agents (correctly) scope to authored code and do not audit
+library internals. This was the first PR to vendor/update an addon, so
+the checklist had no guidance for it.
+
+**Outcome:** 0 new authored-code checklist items (these are not agent
+misses — auditing vendored internals would produce noise on every
+dependency bump). 1 new section added to godot-review
+verification-checklists.md ("10. Vendored Dependencies"): verify
+byte-for-byte upstream match, scope out library internals, disposition
+Copilot findings on vendored files as "keep pristine / report upstream"
+rather than patching. Disposition applied to PR #153: addon kept
+pristine, all 7 threads replied + resolved, no code patched.

--- a/.github/workflows/gut-tests.yml
+++ b/.github/workflows/gut-tests.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  GODOT_VERSION: "4.6.2"
+  GODOT_VERSION: "4.7"
 
 jobs:
   gut-tests:
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Godot
         run: |

--- a/game/addons/gut/awaiter.gd
+++ b/game/addons/gut/awaiter.gd
@@ -196,6 +196,6 @@ func wait_while(predicate_function: Callable, max_time, time_between_calls:=0.0,
 
 
 func is_waiting():
-	return _wait_time != 0.0 || \
-		_wait_physics_frames != 0 || \
+	return _wait_time != 0.0 or \
+		_wait_physics_frames != 0 or \
 		_wait_process_frames != 0

--- a/game/addons/gut/cli/gut_cli.gd
+++ b/game/addons/gut/cli/gut_cli.gd
@@ -154,6 +154,7 @@ an immediate "=":
 	opts.add('-gh', false, 'Print this help.  You did this to see this, so you probably understand.')
 	opts.add('-gpo', false, 'Print option values from all sources and the value used.')
 	opts.add('-gprint_gutconfig_sample', false, 'Print out json that can be used to make a gutconfig file.')
+	opts.add("-gcheck_update", false, "Check for update")
 
 	# run as in editor, for shelling out purposes through Editor.
 	var o = opts.add('-graie', false, 'do not use')
@@ -238,6 +239,15 @@ func _run_tests(opt_resolver):
 		runner.run_tests()
 
 
+var update_detector = null
+func _check_for_update():
+	print(str("Checking for update for GUT ", GutUtils.version_numbers.gut_version))
+	update_detector = GutUtils.UpdateDetector.new()
+	add_child(update_detector)
+	await update_detector.check_for_update_with_fetch()
+	print(update_detector.get_update_string())
+
+
 # parse options and run Gut
 func main():
 	var opt_resolver = OptionResolver.new()
@@ -279,6 +289,9 @@ func main():
 			get_tree().quit(0)
 		elif(cli_opts.get_value('-gprint_gutconfig_sample')):
 			_print_gutconfigs(opt_resolver.get_resolved_values())
+			get_tree().quit(0)
+		elif(cli_opts.get_value('-gcheck_update')):
+			await _check_for_update()
 			get_tree().quit(0)
 		else:
 			_run_tests(opt_resolver)

--- a/game/addons/gut/double_templates/function_template.txt
+++ b/game/addons/gut/double_templates/function_template.txt
@@ -1,9 +1,9 @@
 {func_decleration}
 	if(__gutdbl == null):
-		return
-
-	__gutdbl.spy_on('{method_name}', {param_array})
-	if(__gutdbl.is_stubbed_to_call_super('{method_name}', {param_array})):
 		{super_call}
 	else:
-		return await __gutdbl.handle_other_stubs('{method_name}', {param_array})
+		__gutdbl.spy_on('{method_name}', {param_array})
+		if(__gutdbl.is_stubbed_to_call_super('{method_name}', {param_array})):
+			{super_call}
+		else:
+			{return_it}await __gutdbl.handle_other_stubs('{method_name}', {param_array})

--- a/game/addons/gut/doubler.gd
+++ b/game/addons/gut/doubler.gd
@@ -195,14 +195,14 @@ func _create_double(parsed, strategy, override_path, partial):
 	for method in parsed.get_local_methods():
 		if(_is_method_eligible_for_doubling(parsed, method)):
 			included_methods.append(method.meta.name)
-			dbl_src += _get_func_text(method.meta)
+			dbl_src += _method_maker.get_function_text(method)
 
 	if(strategy == GutUtils.DOUBLE_STRATEGY.INCLUDE_NATIVE):
 		for method in parsed.get_super_methods():
 			if(_is_method_eligible_for_doubling(parsed, method)):
 				included_methods.append(method.meta.name)
 				_stub_to_call_super(parsed, method.meta.name)
-				dbl_src += _get_func_text(method.meta)
+				dbl_src += _method_maker.get_function_text(method)
 
 	var base_script = _get_base_script_text(parsed, override_path, partial, included_methods)
 	dbl_src = base_script + "\n\n" + dbl_src
@@ -238,7 +238,7 @@ func _create_singleton_double(singleton, is_partial):
 	var DblClass = GutUtils.create_script_from_source(dbl_src)
 	if(_stubber != null):
 		for key in parsed.methods_by_name:
-			var meta = parsed.methods_by_name[key]
+			var meta = parsed.methods_by_name[key].meta
 			if(meta != {} and !meta.flags & METHOD_FLAG_VARARG):
 				_stubber.stub_defaults_from_meta(singleton, meta)
 
@@ -248,7 +248,7 @@ func _create_singleton_double(singleton, is_partial):
 func _stub_method_default_values(parsed):
 	for method in parsed.get_local_methods():
 		if(method.is_eligible_for_doubling() and !_ignored_methods.has(parsed.resource, method.meta.name)):
-			_stubber.stub_defaults_from_meta(parsed.script_path, method.meta)
+			_stubber.stub_defaults_from_meta(parsed.resource, method.meta)
 
 
 func _double_scene_and_script(scene, strategy, partial):
@@ -279,10 +279,6 @@ func _get_inst_id_ref_str(inst):
 	if(inst):
 		ref_str = str('instance_from_id(', inst.get_instance_id(),')')
 	return ref_str
-
-
-func _get_func_text(method_hash):
-	return _method_maker.get_function_text(method_hash) + "\n"
 
 
 func _parse_script(obj):

--- a/game/addons/gut/godot_singletons.gd
+++ b/game/addons/gut/godot_singletons.gd
@@ -2,6 +2,7 @@
 # This file is auto-generated as part of the release process.  GUT maintainers
 # should not change this file manually.
 static var class_ref = [
+	AccessibilityServer,
 	AudioServer,
 	CameraServer,
 	ClassDB,
@@ -10,6 +11,7 @@ static var class_ref = [
 	Engine,
 	EngineDebugger,
 	GDExtensionManager,
+	# excluded: GDScriptLanguageProtocol,
 	Geometry2D,
 	Geometry3D,
 	IP,
@@ -42,7 +44,7 @@ static var class_ref = [
 	WorkerThreadPool,
 	XRServer
 ]
-static var names = []
+static var names := []
 static func _static_init():
 	for entry in class_ref:
 		names.append(entry.get_class())

--- a/game/addons/gut/gui/GutBottomPanel.gd
+++ b/game/addons/gut/gui/GutBottomPanel.gd
@@ -48,6 +48,7 @@ var menu_manager = null :
 	settings_button = %ExtraButtons/Settings,
 	shortcut_dialog = $ShortcutDialog,
 	shortcuts_button = %ExtraButtons/Shortcuts,
+	sub_panels_split = $layout/RSplit,
 
 	results = {
 		bar = $layout/ControlBar2,
@@ -355,6 +356,12 @@ func _on_horiz_layout_pressed() -> void:
 func _on_vert_layout_pressed() -> void:
 	results_vert_layout()
 
+
+func _on_resized() -> void:
+	# This wouldn't work in ready or defrred after ready.  the split's y position
+	# was alwasy 0.  This also adapts to Editor font size changes.
+	custom_minimum_size.y = _ctrls.sub_panels_split.position.y
+	
 
 # ---------------
 # Public

--- a/game/addons/gut/gui/GutBottomPanel.tscn
+++ b/game/addons/gut/gui/GutBottomPanel.tscn
@@ -16,7 +16,8 @@
 [sub_resource type="ButtonGroup" id="ButtonGroup_bskl7"]
 
 [node name="GutBottomPanel" type="Control" unique_id=1136630421]
-custom_minimum_size = Vector2(250, 250)
+clip_contents = true
+custom_minimum_size = Vector2(250, 0)
 layout_mode = 3
 anchor_left = -0.0025866
 anchor_top = -0.00176575
@@ -48,7 +49,7 @@ custom_minimum_size = Vector2(1, 2.08165e-12)
 layout_mode = 2
 
 [node name="RunAtCursor" parent="layout/ControlBar" unique_id=1603612118 instance=ExtResource("3")]
-custom_minimum_size = Vector2(237, 0)
+custom_minimum_size = Vector2(488, 0)
 layout_mode = 2
 
 [node name="CenterContainer2" type="CenterContainer" parent="layout/ControlBar" unique_id=269691286]
@@ -270,7 +271,7 @@ size_flags_vertical = 3
 
 [node name="RunResults" parent="layout/RSplit/CResults/HSplitResults" unique_id=1277406275 instance=ExtResource("5")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(255, 255)
+custom_minimum_size = Vector2(255, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -303,6 +304,7 @@ visible = false
 size = Vector2i(1300, 1336)
 visible = false
 
+[connection signal="resized" from="." to="." method="_on_resized"]
 [connection signal="pressed" from="layout/ControlBar/RunAll" to="." method="_on_RunAll_pressed"]
 [connection signal="run_tests" from="layout/ControlBar/RunAtCursor" to="." method="_on_RunAtCursor_run_tests"]
 [connection signal="pressed" from="layout/ControlBar/MakeFloating" to="." method="_on_to_window_pressed"]

--- a/game/addons/gut/gui/ResultsTree.tscn
+++ b/game/addons/gut/gui/ResultsTree.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://dls5r5f6157nq"]
+[gd_scene format=3 uid="uid://dls5r5f6157nq"]
 
 [ext_resource type="Script" uid="uid://dehdhn78qv5tr" path="res://addons/gut/gui/ResultsTree.gd" id="1_b4uub"]
 
-[node name="ResultsTree" type="Tree"]
+[node name="ResultsTree" type="Tree" unique_id=1240770657]
 offset_right = 1082.0
 offset_bottom = 544.0
 size_flags_horizontal = 3
@@ -11,7 +11,7 @@ columns = 2
 hide_root = true
 script = ExtResource("1_b4uub")
 
-[node name="TextOverlay" type="Label" parent="."]
+[node name="TextOverlay" type="Label" parent="." unique_id=1487654929]
 visible = false
 layout_mode = 1
 anchors_preset = 15
@@ -20,7 +20,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="ResultsTree" type="VBoxContainer" parent="."]
+[node name="ResultsTree" type="VBoxContainer" parent="." unique_id=87055617]
 custom_minimum_size = Vector2(10, 10)
 layout_mode = 1
 anchors_preset = 15

--- a/game/addons/gut/gui/ShortcutButton.gd
+++ b/game/addons/gut/gui/ShortcutButton.gd
@@ -124,7 +124,7 @@ func get_input_event():
 	return _source_event
 
 func set_shortcut(sc):
-	if(sc == null or sc.events == null || sc.events.size() <= 0):
+	if(sc == null or sc.events == null or sc.events.size() <= 0):
 		clear_shortcut()
 	else:
 		_source_event = sc.events[0]
@@ -144,8 +144,8 @@ func disable_set(should):
 
 func disable_clear(should):
 	_ctrls.clear_button.disabled = should
-	
-	
+
+
 func cancel():
 	if(_editing):
 		_edit_mode(false)

--- a/game/addons/gut/gui/about.gd
+++ b/game/addons/gut/gui/about.gd
@@ -5,15 +5,13 @@ var GutEditorGlobals = load('res://addons/gut/gui/editor_globals.gd')
 
 var _bbcode = \
 """
-[center]GUT {gut_version}[/center]
-
 [center][b]GUT Links[/b]
 {gut_link_table}[/center]
 
 [center][b]VSCode Extension Links[/b]
 {vscode_link_table}[/center]
 
-[center]You can support GUT development at
+[center]You can support GUT development at:
 {donate_link}
 
 Thanks for using GUT!
@@ -33,17 +31,19 @@ var _vscode_links = [
 ]
 
 var _donate_link = "https://buymeacoffee.com/bitwes"
-
 @onready var _logo = $Logo
-
+@onready var rtl = $HBox/VBoxContainer/Scroll/RichTextLabel
+@onready var check_for_update = $HBox/VBoxContainer/CheckForUpdate
 
 func _ready():
 	if(get_parent() is SubViewport):
 		return
-
+	elif(get_parent() == get_tree().root):
+		size = Vector2(100, 100)
+	title = str("GUT ", GutUtils.version_numbers.gut_version)
 	_vert_center_logo()
-	$Logo.disabled = true
-	$HBox/Scroll/RichTextLabel.text = _make_text()
+	_logo.disabled = true
+	rtl.text = _make_text()
 
 
 func _color_link(link_text):
@@ -62,6 +62,13 @@ func _link_table(entries):
 	return str('[table=2]', text, '[/table]')
 
 
+func url_bbcode(url, link_text=null):
+	if(link_text == null):
+		link_text = url
+	var text = str("[url=", url, "]", link_text, "[/url]")
+	return _color_link(text)
+
+
 func _make_text():
 	var gut_link_table = _link_table(_gut_links)
 	var vscode_link_table = _link_table(_vscode_links)
@@ -70,7 +77,6 @@ func _make_text():
 		"gut_link_table":gut_link_table,
 		"vscode_link_table":vscode_link_table,
 		"donate_link":_color_link(str('[url]', _donate_link, '[/url]')),
-		"gut_version":GutUtils.version_numbers.gut_version,
 	})
 	return text
 
@@ -123,3 +129,8 @@ func _on_rich_text_label_meta_hover_ended(meta: Variant) -> void:
 
 func _on_logo_pressed() -> void:
 	_logo.disabled = !_logo.disabled
+
+
+func _on_check_for_update_verbose_enabled() -> void:
+	check_for_update.size_flags_vertical = check_for_update.SIZE_EXPAND_FILL
+	check_for_update.z_index = 100

--- a/game/addons/gut/gui/about.tscn
+++ b/game/addons/gut/gui/about.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://dqbkylpsatcqm"]
+[gd_scene format=3 uid="uid://dqbkylpsatcqm"]
 
 [ext_resource type="Script" uid="uid://g7qu8ihdt3pd" path="res://addons/gut/gui/about.gd" id="1_bg86c"]
+[ext_resource type="PackedScene" uid="uid://c5om15m2e70qp" path="res://addons/gut/gui/check_for_update.tscn" id="2_kpic4"]
 [ext_resource type="PackedScene" uid="uid://bjkn8mhx2fmt1" path="res://addons/gut/gui/GutLogo.tscn" id="3_kpic4"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q8rky"]
@@ -8,7 +9,7 @@ bg_color = Color(0, 0, 0, 0.49803922)
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_kpic4"]
 
-[node name="About" type="AcceptDialog"]
+[node name="About" type="AcceptDialog" unique_id=1150745302]
 oversampling_override = 1.0
 title = "About GUT"
 position = Vector2i(0, 36)
@@ -17,22 +18,32 @@ visible = true
 min_size = Vector2i(800, 800)
 script = ExtResource("1_bg86c")
 
-[node name="HBox" type="HBoxContainer" parent="."]
+[node name="HBox" type="HBoxContainer" parent="." unique_id=1875890740]
 offset_left = 8.0
 offset_top = 8.0
 offset_right = 1492.0
 offset_bottom = 751.0
 alignment = 1
 
-[node name="MakeRoomForLogo" type="CenterContainer" parent="HBox"]
+[node name="MakeRoomForLogo" type="CenterContainer" parent="HBox" unique_id=1274652102]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 
-[node name="Scroll" type="ScrollContainer" parent="HBox"]
+[node name="VBoxContainer" type="VBoxContainer" parent="HBox" unique_id=1594624944]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/separation = 0
 
-[node name="RichTextLabel" type="RichTextLabel" parent="HBox/Scroll"]
+[node name="CheckForUpdate" parent="HBox/VBoxContainer" unique_id=381385621 instance=ExtResource("2_kpic4")]
+custom_minimum_size = Vector2(0, 76)
+layout_mode = 2
+
+[node name="Scroll" type="ScrollContainer" parent="HBox/VBoxContainer" unique_id=1684204946]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="RichTextLabel" type="RichTextLabel" parent="HBox/VBoxContainer/Scroll" unique_id=1217183710]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -41,7 +52,7 @@ theme_override_styles/focus = SubResource("StyleBoxEmpty_kpic4")
 bbcode_enabled = true
 fit_content = true
 
-[node name="Logo" parent="." instance=ExtResource("3_kpic4")]
+[node name="Logo" parent="." unique_id=2097718136 instance=ExtResource("3_kpic4")]
 modulate = Color(0.74509805, 0.74509805, 0.74509805, 1)
 position = Vector2(151, 265)
 scale = Vector2(0.8, 0.8)
@@ -50,7 +61,8 @@ disabled = true
 
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
-[connection signal="meta_clicked" from="HBox/Scroll/RichTextLabel" to="." method="_on_rich_text_label_meta_clicked"]
-[connection signal="meta_hover_ended" from="HBox/Scroll/RichTextLabel" to="." method="_on_rich_text_label_meta_hover_ended"]
-[connection signal="meta_hover_started" from="HBox/Scroll/RichTextLabel" to="." method="_on_rich_text_label_meta_hover_started"]
+[connection signal="verbose_enabled" from="HBox/VBoxContainer/CheckForUpdate" to="." method="_on_check_for_update_verbose_enabled"]
+[connection signal="meta_clicked" from="HBox/VBoxContainer/Scroll/RichTextLabel" to="." method="_on_rich_text_label_meta_clicked"]
+[connection signal="meta_hover_ended" from="HBox/VBoxContainer/Scroll/RichTextLabel" to="." method="_on_rich_text_label_meta_hover_ended"]
+[connection signal="meta_hover_started" from="HBox/VBoxContainer/Scroll/RichTextLabel" to="." method="_on_rich_text_label_meta_hover_started"]
 [connection signal="pressed" from="Logo" to="." method="_on_logo_pressed"]

--- a/game/addons/gut/gui/check_for_update.gd
+++ b/game/addons/gut/gui/check_for_update.gd
@@ -1,0 +1,152 @@
+@tool
+extends Control
+
+static var fetch_count = 0
+static var max_fetches = 5
+
+var update_detector = null
+@onready var rtl = $Output
+var _log_entries = []
+var _verbose = false :
+	set(val):
+		if(!_verbose and val):
+			verbose_enabled.emit()
+		_verbose = val
+var _mouse_down_duration = 0.0
+var _mouse_down = false
+var _mouse_down_time_to_show_verbose := 4.0
+
+signal verbose_enabled
+
+func _debug_ready():
+	_verbose = true
+
+func _ready():
+	update_detector = GutUtils.UpdateDetector.new()
+	add_child(update_detector)
+	update_detector.updated.connect(_on_update_detector_updated)
+	update_detector.download_completed.connect(_on_update_detector_download)
+
+	check_for_update(false, false)
+	_log(update_detector.get_summary_string())
+	_populate_text()
+
+	if(get_parent() == get_tree().root):
+		_debug_ready()
+
+
+func _process(delta: float) -> void:
+	if(_mouse_down_duration < _mouse_down_time_to_show_verbose and _mouse_down):
+		_mouse_down_duration += delta
+		if(_mouse_down_duration >= _mouse_down_time_to_show_verbose):
+			_verbose = true
+			rtl.append_text("\nVERBOSE ENABLED\n")
+			rtl.append_text(_get_check_for_update_link())
+
+
+# ----------------
+# Private
+# ----------------
+
+func _log(text):
+	if(_verbose):
+		_log_entries.append(str(text))
+
+
+func _log_file(path):
+	if(_verbose):
+		var file_text = FileAccess.get_file_as_string(path)
+		if(file_text == ""):
+			file_text = "--Missing or empty file--"
+		_log(str(path, ":\n[code]", file_text, "[/code]"))
+
+
+func _get_check_for_update_link():
+	if(_verbose or update_detector.fetch_limit_wait_time() <= 0.0):
+		return str("[center]", _url_bbcode("_check_for_update", "Check for Update", "ORANGE"), "[/center]")
+	else:
+		return ''
+
+
+func check_for_update(use_fetch, force=false):
+	_log_entries.clear()
+	rtl.text = ""
+	update_detector.check_for_update()
+	if(use_fetch):
+		fetch_count += 1
+		rtl.text = "Checking..."
+		_log("fetching remote file " + update_detector.REMOTE_FILE_URL)
+		update_detector.check_for_update_with_fetch(force)
+	else:
+		_log("local check")
+		update_detector.check_for_update()
+
+
+func _populate_text():
+	var txt = ""
+	if(!update_detector.is_empty()):
+		txt = str("[center]", update_detector.get_update_string(_url_bbcode), "[/center]")
+	if(_verbose):
+		txt = txt + "\n\n" + "\n".join(_log_entries)
+	rtl.text = txt + "\n" + _get_check_for_update_link()
+	_post_populate.call_deferred()
+
+
+func _post_populate():
+	custom_minimum_size.y = min(rtl.get_content_height() + 30, 400)
+
+
+func _url_bbcode(url, link_text=null, color_name="ROYAL_BLUE"):
+	if(link_text == null):
+		link_text = url
+	var text = str("[url=", url, "]", link_text, "[/url]")
+	return str("[color=", color_name, "]", text, "[/color]")
+
+
+# -----------------
+# Events
+# -----------------
+func _on_update_detector_updated():
+	_log_file(update_detector.REMOTE_FILE_PATH)
+	_log_file(update_detector.LOCAL_FILE_PATH)
+	_log(str("Local:\n[code]", JSON.stringify(update_detector.local_data.get_data(), "  "), "[/code]"))
+	_log(str("Local Issues:\n", update_detector.local_data.data_issues))
+	_log(str("Remote:\n[code]", JSON.stringify(update_detector.remote_data.get_data(), "  "), "[/code]"))
+	_log(str("Remote Issues:\n", update_detector.remote_data.data_issues))
+
+	_log(update_detector.get_summary_string())
+	_populate_text()
+
+
+func _on_btn_check_button_up() -> void:
+	check_for_update(true, true)
+
+
+func _on_update_detector_download():
+	_log("Download completed")
+
+
+func _on_output_meta_clicked(meta: Variant) -> void:
+	if(meta == "_check_for_update"):
+		check_for_update(true, true)
+	else:
+		OS.shell_open(str(meta))
+
+
+func _on_output_gui_input(event: InputEvent) -> void:
+	if(event is InputEventMouseButton):
+		if(event.pressed):
+			_mouse_down = true
+		else:
+			_mouse_down = false
+			_mouse_down_duration = 0.0
+
+
+func _on_output_resized() -> void:
+	if(rtl != null):
+		custom_minimum_size.y = rtl.get_visible_content_rect().size.y + 20
+
+
+func _on_mouse_exited() -> void:
+	_mouse_down = false
+	_mouse_down = 0.0

--- a/game/addons/gut/gui/check_for_update.tscn
+++ b/game/addons/gut/gui/check_for_update.tscn
@@ -1,0 +1,45 @@
+[gd_scene format=3 uid="uid://c5om15m2e70qp"]
+
+[ext_resource type="Script" uid="uid://bomsutomy3pdy" path="res://addons/gut/gui/check_for_update.gd" id="1_70x43"]
+[ext_resource type="FontFile" uid="uid://bnh0lslf4yh87" path="res://addons/gut/fonts/CourierPrime-Regular.ttf" id="2_lsin2"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lsin2"]
+content_margin_left = 20.0
+content_margin_top = 20.0
+content_margin_right = 20.0
+content_margin_bottom = 20.0
+bg_color = Color(0.09239707, 0.09239706, 0.09239706, 0.49803922)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+
+[node name="CheckForUpdate" type="Control" unique_id=381385621]
+custom_minimum_size = Vector2(0, 53)
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+script = ExtResource("1_70x43")
+
+[node name="Output" type="RichTextLabel" parent="." unique_id=1256208807]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+focus_mode = 2
+theme_override_fonts/mono_font = ExtResource("2_lsin2")
+theme_override_styles/normal = SubResource("StyleBoxFlat_lsin2")
+bbcode_enabled = true
+text = "[center][color=ROYAL_BLUE][url=https://github.com/bitwes/Gut/releases/tag/v0.0.0]GUT 0.0.0[/url][/color] is now available![/center]
+"
+selection_enabled = true
+
+[connection signal="gui_input" from="Output" to="." method="_on_output_gui_input"]
+[connection signal="meta_clicked" from="Output" to="." method="_on_output_meta_clicked"]
+[connection signal="resized" from="Output" to="." method="_on_output_resized"]

--- a/game/addons/gut/gui/editor_globals.gd
+++ b/game/addons/gut/gui/editor_globals.gd
@@ -1,7 +1,7 @@
 @tool
 
 static var GutUserPreferences = load("res://addons/gut/gui/gut_user_preferences.gd")
-static var temp_directory = 'user://gut_temp_directory'
+static var temp_directory = 'user://gut_temp_directory/'
 
 static var editor_run_gut_config_path = 'gut_editor_config.json':
 	# This avoids having to use path_join wherever we want to reference this

--- a/game/addons/gut/gui/update_required.gd
+++ b/game/addons/gut/gui/update_required.gd
@@ -1,0 +1,30 @@
+@tool
+extends AcceptDialog
+
+var should_continue = false
+var _check_for_update_ctrl = null
+
+signal closed
+
+func _ready():
+	add_cancel_button("Cancel Loading GUT")
+
+
+func _on_confirmed() -> void:
+	should_continue = true
+	closed.emit.call_deferred()
+
+
+func _on_canceled() -> void:
+	should_continue = false
+	closed.emit.call_deferred()
+
+
+func _on_close_requested() -> void:
+	should_continue = false
+	closed.emit.call_deferred()
+
+
+func set_check_for_update_control(ctrl):
+	_check_for_update_ctrl = ctrl
+	add_child(ctrl)

--- a/game/addons/gut/gui/update_required.tscn
+++ b/game/addons/gut/gui/update_required.tscn
@@ -1,0 +1,17 @@
+[gd_scene format=3 uid="uid://sduiv3grt5h4"]
+
+[ext_resource type="Script" uid="uid://bpj4k0w6ft550" path="res://addons/gut/gui/update_required.gd" id="1_rmy01"]
+
+[node name="UpdateRequired" type="AcceptDialog" unique_id=125541884]
+oversampling_override = 1.0
+title = "Invalid GUT Version"
+position = Vector2i(0, 36)
+size = Vector2i(600, 300)
+visible = true
+exclusive = false
+ok_button_text = "Continue"
+script = ExtResource("1_rmy01")
+
+[connection signal="canceled" from="." to="." method="_on_canceled"]
+[connection signal="close_requested" from="." to="." method="_on_close_requested"]
+[connection signal="confirmed" from="." to="." method="_on_confirmed"]

--- a/game/addons/gut/gut.gd
+++ b/game/addons/gut/gut.gd
@@ -2,7 +2,7 @@ extends 'res://addons/gut/gut_to_move.gd'
 class_name GutMain
 ## The GUT brains.
 ##
-## Most of this class is for internal use only.  Features that can be used are
+## Most of this class is for internal use only.  Features that can be used
 ## have descriptions and can be accessed through the [member GutTest.gut] variable
 ## in your test scripts (extends [GutTest]).
 ## The wiki page for this class contains only the usable features.
@@ -30,9 +30,16 @@ signal end_pause_before_teardown
 
 signal start_run
 signal end_run
+## Emitted before every test script instance is created.
+## Emitted before [method GutTest.before_all] hook on test is run.
+## test_script_obj is an instance of addons/gut/collected_script.gd.
 signal start_script(test_script_obj)
+## Emitted after every test script is run. Emitted after [method GutTest.after_all] hook on test is run.
 signal end_script
+## Emitted before every test method is run. Emitted after [method GutTest.before_each] hook on test is run.
+## test_name is the string name of the current test about to be started.
 signal start_test(test_name)
+## Emitted after every test method is run. Emitted after [method GutTest.after_each] hook on test is run.
 signal end_test
 
 
@@ -644,10 +651,18 @@ func _run_test(script_inst, test_name, param_index = -1):
 
 
 func get_current_test_orphans():
-	var sname = get_current_test_object().collected_script.get_ref().get_filename_and_inner()
-	var tname = get_current_test_object().name
-	_orphan_counter.record_orphans(sname, tname)
-	return _orphan_counter.get_orphan_ids(sname, tname)
+	var to_return = []
+	var ct = get_current_test_object()
+	if(ct.collected_script != null):
+		var sname = ct.collected_script.get_ref().get_filename_and_inner()
+		if(ct.name == &'after_all' or ct.name == &'before_all'):
+			_orphan_counter.record_orphans(sname)
+			to_return = _orphan_counter.get_orphan_ids(sname)
+			to_return.append_array(_orphan_counter.get_orphan_ids(ct.collected_script.get_ref().get_full_name()))
+		else:
+			to_return = _orphan_counter.record_orphans(sname, ct.name)
+
+	return to_return
 
 
 # ------------------------------------------------------------------------------
@@ -663,6 +678,7 @@ func _call_before_all(test_script, collected_script):
 
 	collected_script.setup_teardown_tests.append(before_all_test_obj)
 	_current_test = before_all_test_obj
+	_current_test.collected_script = weakref(collected_script)
 
 	_lgr.inc_indent()
 	await test_script.before_all()
@@ -688,6 +704,7 @@ func _call_after_all(test_script, collected_script):
 
 	collected_script.setup_teardown_tests.append(after_all_test_obj)
 	_current_test = after_all_test_obj
+	_current_test.collected_script = weakref(collected_script)
 
 	_lgr.inc_indent()
 	await test_script.after_all()

--- a/game/addons/gut/gut_cmdln.gd
+++ b/game/addons/gut/gut_cmdln.gd
@@ -20,7 +20,8 @@ func _init() -> void:
 	var max_iter := 20
 	var iter := 0
 
-	var Loader : Object = load("res://addons/gut/gut_loader.gd")
+	# Make a reference to gut_loader so its _static_init is run.
+	var Laoder : Object = load("res://addons/gut/gut_loader.gd")
 
 	# Not seen this wait more than 1.
 	while(Engine.get_main_loop() == null and iter < max_iter):

--- a/game/addons/gut/gut_constants.gd
+++ b/game/addons/gut/gut_constants.gd
@@ -1,0 +1,130 @@
+class_name GutConstants
+
+const TYPE_STRINGS = {
+	TYPE_NIL : 'TYPE_NIL',
+	TYPE_BOOL : 'TYPE_BOOL',
+	TYPE_INT : 'TYPE_INT',
+	TYPE_FLOAT : 'TYPE_FLOAT',
+	TYPE_STRING : 'TYPE_STRING',
+	TYPE_VECTOR2 : 'TYPE_VECTOR2',
+	TYPE_VECTOR2I : 'TYPE_VECTOR2I',
+	TYPE_RECT2 : 'TYPE_RECT2',
+	TYPE_RECT2I : 'TYPE_RECT2I',
+	TYPE_VECTOR3 : 'TYPE_VECTOR3',
+	TYPE_VECTOR3I : 'TYPE_VECTOR3I',
+	TYPE_TRANSFORM2D : 'TYPE_TRANSFORM2D',
+	TYPE_VECTOR4 : 'TYPE_VECTOR4',
+	TYPE_VECTOR4I : 'TYPE_VECTOR4I',
+	TYPE_PLANE : 'TYPE_PLANE',
+	TYPE_QUATERNION : 'TYPE_QUATERNION',
+	TYPE_AABB : 'TYPE_AABB',
+	TYPE_BASIS : 'TYPE_BASIS',
+	TYPE_TRANSFORM3D : 'TYPE_TRANSFORM3D',
+	TYPE_PROJECTION : 'TYPE_PROJECTION',
+	TYPE_COLOR : 'TYPE_COLOR',
+	TYPE_STRING_NAME : 'TYPE_STRING_NAME',
+	TYPE_NODE_PATH : 'TYPE_NODE_PATH',
+	TYPE_RID : 'TYPE_RID',
+	TYPE_OBJECT : 'TYPE_OBJECT',
+	TYPE_CALLABLE : 'TYPE_CALLABLE',
+	TYPE_SIGNAL : 'TYPE_SIGNAL',
+	TYPE_DICTIONARY : 'TYPE_DICTIONARY',
+	TYPE_ARRAY : 'TYPE_ARRAY',
+	TYPE_PACKED_BYTE_ARRAY : 'TYPE_PACKED_BYTE_ARRAY',
+	TYPE_PACKED_INT32_ARRAY : 'TYPE_PACKED_INT32_ARRAY',
+	TYPE_PACKED_INT64_ARRAY : 'TYPE_PACKED_INT64_ARRAY',
+	TYPE_PACKED_FLOAT32_ARRAY : 'TYPE_PACKED_FLOAT32_ARRAY',
+	TYPE_PACKED_FLOAT64_ARRAY : 'TYPE_PACKED_FLOAT64_ARRAY',
+	TYPE_PACKED_STRING_ARRAY : 'TYPE_PACKED_STRING_ARRAY',
+	TYPE_PACKED_VECTOR2_ARRAY : 'TYPE_PACKED_VECTOR2_ARRAY',
+	TYPE_PACKED_VECTOR3_ARRAY : 'TYPE_PACKED_VECTOR3_ARRAY',
+	TYPE_PACKED_COLOR_ARRAY : 'TYPE_PACKED_COLOR_ARRAY',
+	TYPE_PACKED_VECTOR4_ARRAY : 'TYPE_PACKED_VECTOR4_ARRAY',
+	TYPE_MAX : 'TYPE_MAX',
+}
+
+# Values should not be referenced outside of this script.
+# Use get_default_return_value.  The functions look weird, but they are here
+# so that each call to a doubled method returns a unique instance of things for
+# anything that would be passed by reference.
+static var _default_returns = {
+	TYPE_NIL : null,
+	TYPE_BOOL : false,
+	TYPE_INT : 0,
+	TYPE_FLOAT : 0.0,
+	TYPE_STRING : '',
+	TYPE_VECTOR2 : Vector2.ZERO,
+	TYPE_VECTOR2I : Vector2i.ZERO,
+	TYPE_RECT2 : func(): return Rect2(0, 0, 0, 0),
+	TYPE_RECT2I : func(): return Rect2i(0, 0, 0, 0),
+	TYPE_VECTOR3 : Vector3.ZERO,
+	TYPE_VECTOR3I : Vector3i.ZERO,
+	TYPE_TRANSFORM2D : Transform2D.IDENTITY,
+	TYPE_VECTOR4 : Vector4.ZERO,
+	TYPE_VECTOR4I : Vector4i.ZERO,
+	TYPE_PLANE : Plane.PLANE_XY,
+	TYPE_QUATERNION : Quaternion.IDENTITY,
+	TYPE_AABB : func(): return AABB(),
+	TYPE_BASIS : Basis.IDENTITY,
+	TYPE_TRANSFORM3D : Transform3D.IDENTITY,
+	TYPE_PROJECTION : Projection.IDENTITY,
+	TYPE_COLOR : Color.WHITE,
+	TYPE_STRING_NAME : &'',
+	TYPE_NODE_PATH : func(): return NodePath(),
+	TYPE_RID : func(): return RID(),
+	TYPE_OBJECT : null,
+	TYPE_CALLABLE : func(): return Callable(),
+	TYPE_SIGNAL : null,
+	TYPE_DICTIONARY : func(): return {},
+	TYPE_ARRAY : func(): return [],
+	TYPE_PACKED_BYTE_ARRAY : func(): return PackedByteArray(),
+	TYPE_PACKED_INT32_ARRAY : func(): return PackedInt32Array(),
+	TYPE_PACKED_INT64_ARRAY : func(): return PackedInt64Array(),
+	TYPE_PACKED_FLOAT32_ARRAY : func(): return PackedFloat32Array(),
+	TYPE_PACKED_FLOAT64_ARRAY : func(): return PackedFloat64Array(),
+	TYPE_PACKED_STRING_ARRAY : func(): return PackedStringArray(),
+	TYPE_PACKED_VECTOR2_ARRAY : func(): return PackedVector2Array(),
+	TYPE_PACKED_VECTOR3_ARRAY : func(): return PackedVector3Array(),
+	TYPE_PACKED_COLOR_ARRAY : func(): return PackedColorArray(),
+	TYPE_PACKED_VECTOR4_ARRAY : func(): return PackedVector4Array(),
+	# TYPE_MAX : 'TYPE_MAX',
+}
+
+# Seeded with any type constant where the constant name can't be converted to
+# a string using pascal case and/or the values need manual conversion.  The
+# rest are added in _static_init.
+static var TYPE_KEYWORDS = {
+	TYPE_NIL : 'null',
+	TYPE_BOOL : 'bool',
+	TYPE_INT : 'int',
+	TYPE_FLOAT : 'float',
+}
+
+
+static var NOT_SET := &"___NOT__SET___"
+
+
+static func _static_init() -> void:
+	for key in TYPE_STRINGS:
+		if(!TYPE_KEYWORDS.has(key)):
+			var n : String = TYPE_STRINGS[key].to_lower()
+			n = n.lstrip("type_")
+			TYPE_KEYWORDS[key] = n.to_pascal_case()
+
+
+static func is_not_set(val):
+	return typeof(val) == TYPE_STRING_NAME and val == NOT_SET
+
+
+static func get_default_return_value(type=null):
+	if(type == null or typeof(type) != TYPE_INT):
+		return null
+	var to_return = null
+	if(is_not_set(type)):
+		to_return = null
+	elif(_default_returns.has(type)):
+		to_return = _default_returns[type]
+		if(to_return is Callable):
+			to_return = to_return.call()
+
+	return to_return

--- a/game/addons/gut/gut_plugin.gd
+++ b/game/addons/gut/gut_plugin.gd
@@ -6,6 +6,8 @@ var MenuManager = load("res://addons/gut/gut_menu.gd")
 var BottomPanelScene = preload('res://addons/gut/gui/GutBottomPanel.tscn')
 var GutEditorGlobals = load('res://addons/gut/gui/editor_globals.gd')
 var GutDock = load('res://addons/gut/gui/gut_dock.gd')
+var UpdateRequiredDialog = load('res://addons/gut/gui/update_required.tscn')
+var CheckForUpdateControl = load("res://addons/gut/gui/check_for_update.tscn")
 
 var _bottom_panel : Control = null
 var _menu_mgr = null
@@ -13,6 +15,8 @@ var _gut_button = null
 var _gut_window = null
 var _dock_mode = 'none'
 var _gut_dock = null
+var _update_required = null
+var _check_for_update = null
 
 
 func _init():
@@ -20,8 +24,37 @@ func _init():
 		return
 
 
+# This checks the Remote file or Local file.  This will not download the
+# remote file.  I don't want to delay startup for any reason.  Downloading
+# the remote file ocassionally is handled elsewhere.
+func _should_continue_loading_gut():
+	_check_for_update = CheckForUpdateControl.instantiate()
+	var to_return = true
+
+	_update_required = UpdateRequiredDialog.instantiate()
+	get_tree().root.add_child(_update_required)
+	_update_required.set_check_for_update_control(_check_for_update)
+
+	if(!_check_for_update.update_detector.is_gut_version_valid()):
+		_update_required.popup_centered()
+		await(_update_required.closed)
+
+		if(!_update_required.should_continue):
+			to_return = false
+
+	_update_required.remove_child(_check_for_update)
+	_update_required.queue_free()
+
+	return to_return
+
+
 func _enter_tree():
 	if(!_version_conversion()):
+		return
+
+	var should_continue = await _should_continue_loading_gut()
+	if(!should_continue):
+		print("GUT loading canceled.  Restart editor to try loading again.")
 		return
 
 	_bottom_panel = BottomPanelScene.instantiate()
@@ -42,6 +75,14 @@ func _enter_tree():
 	await get_tree().create_timer(1).timeout
 	# ---
 
+	# Kick off a download of the remote versions file if it's been more than
+	# some number of days since we've downloaded it.
+	_check_for_update.visible = false
+	_bottom_panel.add_child(_check_for_update)
+	var days_since = _check_for_update.update_detector.get_days_since_last_fetch()
+	if(days_since >= 1):
+		_check_for_update.update_detector.check_for_update_with_fetch(true)
+
 	_bottom_panel.set_interface(get_editor_interface())
 	_bottom_panel.set_plugin(self)
 	_bottom_panel.load_shortcuts()
@@ -52,7 +93,6 @@ func _enter_tree():
 	add_tool_submenu_item("GUT", _menu_mgr.sub_menu)
 
 	GutEditorGlobals.gut_plugin = self
-
 
 
 func _version_conversion():
@@ -81,19 +121,23 @@ func gut_as_panel():
 
 
 func toggle_windowed():
-	push_warning("You have to right click the GUT tab and choos 'floating'.  I cannot do this from a menu anymore.")
+	push_warning("You have to right click the GUT tab and choose 'floating'.  I cannot do this from a menu anymore.")
 
 
 func _exit_tree():
 	remove_tool_menu_item("GUT")
 	_menu_mgr = null
 	GutEditorGlobals.user_prefs.save_it()
+	
+	if(_bottom_panel != null):
+		_bottom_panel.menu_manager = null
 
-	_bottom_panel.menu_manager = null
-
-	remove_dock(_gut_dock)
-	_gut_dock.queue_free()
+	if(_gut_dock != null):
+		remove_dock(_gut_dock)
+		_gut_dock.queue_free()
 	remove_tool_menu_item("GUT") # made by _menu_mgr
+
+	_check_for_update.queue_free()
 
 
 func show_output_panel():

--- a/game/addons/gut/hook_script.gd
+++ b/game/addons/gut/hook_script.gd
@@ -33,7 +33,6 @@ func run():
 	gut.logger.error("Run method not overloaded.  Create a 'run()' method in your hook script to run your code.")
 
 ## Register inner classes from one or more scripts for doubling.
-## `scripts` may be either a script or an array of scripts.
 ## Only worth calling from pre-run hook, not post-run.
 func register_inner_classes(script: Script):
 	gut.get_doubler().inner_class_registry.register(script)

--- a/game/addons/gut/logger.gd
+++ b/game/addons/gut/logger.gd
@@ -26,18 +26,18 @@ var fmts = {
 }
 
 var _type_data = {
-	types.debug:		{disp='DEBUG', 		enabled=true, fmt=fmts.bold},
-	types.deprecated:	{disp='DEPRECATED', enabled=true, fmt=fmts.none},
-	types.error:		{disp='ERROR', 		enabled=true, fmt=fmts.red},
+	types.debug:		{disp='DEBUG', 			enabled=true, fmt=fmts.bold},
+	types.deprecated:	{disp='DEPRECATED', 	enabled=true, fmt=fmts.none},
+	types.error:		{disp='GUT ERROR', 		enabled=true, fmt=fmts.red},
 	types.expected_error:	{disp="ExpectedError", enabled=true, fmt=fmts.blue},
-	types.failed:		{disp='Failed', 	enabled=true, fmt=fmts.red},
-	types.info:			{disp='INFO', 		enabled=true, fmt=fmts.bold},
-	types.normal:		{disp='NORMAL', 	enabled=true, fmt=fmts.none},
-	types.orphan:		{disp='Orphans',	enabled=true, fmt=fmts.yellow},
-	types.passed:		{disp='Passed', 	enabled=true, fmt=fmts.green},
-	types.pending:		{disp='Pending',	enabled=true, fmt=fmts.yellow},
-	types.risky:		{disp='Risky',		enabled=true, fmt=fmts.yellow},
-	types.warn:			{disp='WARNING', 	enabled=true, fmt=fmts.yellow},
+	types.failed:		{disp='Failed', 		enabled=true, fmt=fmts.red},
+	types.info:			{disp='INFO', 			enabled=true, fmt=fmts.bold},
+	types.normal:		{disp='NORMAL', 		enabled=true, fmt=fmts.none},
+	types.orphan:		{disp='Orphans',		enabled=true, fmt=fmts.yellow},
+	types.passed:		{disp='Passed', 		enabled=true, fmt=fmts.green},
+	types.pending:		{disp='Pending',		enabled=true, fmt=fmts.yellow},
+	types.risky:		{disp='Risky',			enabled=true, fmt=fmts.yellow},
+	types.warn:			{disp='GUT WARNING', 	enabled=true, fmt=fmts.yellow},
 }
 
 var _logs = {

--- a/game/addons/gut/method_maker.gd
+++ b/game/addons/gut/method_maker.gd
@@ -14,6 +14,8 @@ class CallParameters:
 			return str(p_name, "=", default)
 
 
+
+
 # ------------------------------------------------------------------------------
 # This class will generate method declaration lines based on method meta
 # data.  It will create defaults that match the method data.
@@ -32,93 +34,17 @@ class CallParameters:
 # 	(usage:7)
 # }]
 # default_args []
-
-var _lgr = GutUtils.get_logger()
 const PARAM_PREFIX = 'p_'
 
-# ------------------------------------------------------
-# _supported_defaults
-#
-# This array contains all the data types that are supported for default values.
-# If a value is supported it will contain either an empty string or a prefix
-# that should be used when setting the parameter default value.
-# For example int, real, bool do not need anything func(p1=1, p2=2.2, p3=false)
-# but things like Vectors and Colors do since only the parameters to create a
-# new Vector or Color are included in the metadata.
-# ------------------------------------------------------
-	# TYPE_NIL = 0 — Variable is of type nil (only applied for null).
-	# TYPE_BOOL = 1 — Variable is of type bool.
-	# TYPE_INT = 2 — Variable is of type int.
-	# TYPE_FLOAT = 3 — Variable is of type float/real.
-	# TYPE_STRING = 4 — Variable is of type String.
-	# TYPE_VECTOR2 = 5 — Variable is of type Vector2.
-	# TYPE_RECT2 = 6 — Variable is of type Rect2.
-	# TYPE_VECTOR3 = 7 — Variable is of type Vector3.
-	# TYPE_COLOR = 14 — Variable is of type Color.
-	# TYPE_OBJECT = 17 — Variable is of type Object.
-	# TYPE_DICTIONARY = 18 — Variable is of type Dictionary.
-	# TYPE_ARRAY = 19 — Variable is of type Array.
-	# TYPE_PACKED_VECTOR2_ARRAY = 24 — Variable is of type PackedVector2Array.
-	# TYPE_TRANSFORM3D = 13 — Variable is of type Transform3D.
-	# TYPE_TRANSFORM2D = 8 — Variable is of type Transform2D.
-	# TYPE_RID = 16 — Variable is of type RID.
-	# TYPE_PACKED_INT32_ARRAY = 21 — Variable is of type PackedInt32Array.
-	# TYPE_PACKED_FLOAT32_ARRAY = 22 — Variable is of type PackedFloat32Array.
-	# TYPE_PACKED_STRING_ARRAY = 23 — Variable is of type PackedStringArray.
 
-
-# TYPE_PLANE = 9 — Variable is of type Plane.
-# TYPE_QUATERNION = 10 — Variable is of type Quaternion.
-# TYPE_AABB = 11 — Variable is of type AABB.
-# TYPE_BASIS = 12 — Variable is of type Basis.
-# TYPE_NODE_PATH = 15 — Variable is of type NodePath.
-# TYPE_PACKED_BYTE_ARRAY = 20 — Variable is of type PackedByteArray.
-# TYPE_PACKED_VECTOR3_ARRAY = 25 — Variable is of type PackedVector3Array.
-# TYPE_PACKED_COLOR_ARRAY = 26 — Variable is of type PackedColorArray.
-# TYPE_MAX = 27 — Marker for end of type constants.
-# ------------------------------------------------------
-var _supported_defaults = []
-
-func _init():
-	for _i in range(TYPE_MAX):
-		_supported_defaults.append(null)
-
-	# These types do not require a prefix for defaults
-	_supported_defaults[TYPE_NIL] = ''
-	_supported_defaults[TYPE_BOOL] = ''
-	_supported_defaults[TYPE_INT] = ''
-	_supported_defaults[TYPE_FLOAT] = ''
-	_supported_defaults[TYPE_OBJECT] = ''
-	_supported_defaults[TYPE_ARRAY] = ''
-	_supported_defaults[TYPE_STRING] = ''
-	_supported_defaults[TYPE_STRING_NAME] = ''
-	_supported_defaults[TYPE_DICTIONARY] = ''
-	_supported_defaults[TYPE_PACKED_VECTOR2_ARRAY] = ''
-	_supported_defaults[TYPE_RID] = ''
-
-	# These require a prefix for whatever default is provided
-	_supported_defaults[TYPE_VECTOR2] = 'Vector2'
-	_supported_defaults[TYPE_VECTOR2I] = 'Vector2i'
-	_supported_defaults[TYPE_RECT2] = 'Rect2'
-	_supported_defaults[TYPE_RECT2I] = 'Rect2i'
-	_supported_defaults[TYPE_VECTOR3] = 'Vector3'
-	_supported_defaults[TYPE_COLOR] = 'Color'
-	_supported_defaults[TYPE_TRANSFORM2D] = 'Transform2D'
-	_supported_defaults[TYPE_TRANSFORM3D] = 'Transform3D'
-	_supported_defaults[TYPE_PACKED_INT32_ARRAY] = 'PackedInt32Array'
-	_supported_defaults[TYPE_PACKED_FLOAT32_ARRAY] = 'PackedFloat32Array'
-	_supported_defaults[TYPE_PACKED_STRING_ARRAY] = 'PackedStringArray'
+var _lgr = GutUtils.get_logger()
+static var _func_template = GutUtils.get_file_as_text('res://addons/gut/double_templates/function_template.txt')
+static var _init_template = GutUtils.get_file_as_text('res://addons/gut/double_templates/init_template.txt')
 
 
 # ###############
 # Private
 # ###############
-var _func_text = GutUtils.get_file_as_text('res://addons/gut/double_templates/function_template.txt')
-var _init_text = GutUtils.get_file_as_text('res://addons/gut/double_templates/init_template.txt')
-
-func _is_supported_default(type_flag):
-	return type_flag >= 0 and type_flag < _supported_defaults.size() and _supported_defaults[type_flag] != null
-
 
 func _make_stub_default(method, index):
 	return str('__gutdbl.default_val("', method, '",', index, ')')
@@ -126,8 +52,6 @@ func _make_stub_default(method, index):
 
 func _make_arg_array(method_meta):
 	var to_return = []
-
-	var has_unsupported_defaults = false
 
 	for i in range(method_meta.args.size()):
 		var pname = method_meta.args[i].name
@@ -139,7 +63,7 @@ func _make_arg_array(method_meta):
 		cp.vararg = true
 		to_return.append(cp)
 
-	return [has_unsupported_defaults, to_return];
+	return to_return
 
 
 # Creates a list of parameters with defaults of null unless a default value is
@@ -160,20 +84,28 @@ func _get_arg_text(arg_array):
 
 
 # creates a call to the function in meta in the super's class.
-func _get_super_call_text(meta, args, singleton):
-	if meta.flags & MethodFlags.METHOD_FLAG_VIRTUAL_REQUIRED != 0:
-		return '__gutdbl.gut_ref.get_ref().get_logger().error("Cannot call super() because method %s is abstract."); return null' \
-			% meta.name
+func _get_super_call_text(parsed_method, singleton):
+	var return_it = ''
+	if(parsed_method.return_type_text != 'void'):
+		return_it = 'return '
+
+	if parsed_method.meta.flags & MethodFlags.METHOD_FLAG_VIRTUAL_REQUIRED != 0:
+		if(return_it != ''):
+			return_it = '; return null'
+		return '__gutdbl.gut_ref.get_ref().get_logger().error(' + \
+			'"Cannot call super() because method %s is abstract.")%s' \
+			% [parsed_method.meta.name, return_it]
 
 	var params = ''
-	for i in range(args.size()):
-		params += args[i].p_name
-		if(i != args.size() -1):
+	for i in range(parsed_method.args.size()):
+		params += PARAM_PREFIX + parsed_method.args[i].name
+		if(i != parsed_method.args.size() -1):
 			params += ', '
+
 	if(singleton != null):
-		return str('return await __gutdbl.get_singleton().', meta.name, '(', params, ')')
+		return str(return_it, 'await __gutdbl.get_singleton().', parsed_method.meta.name, '(', params, ')')
 	else:
-		return str('return await super(', params, ')')
+		return str(return_it, 'await super(', params, ')')
 
 
 func _get_spy_call_parameters_text(args):
@@ -190,10 +122,6 @@ func _get_spy_call_parameters_text(args):
 	return called_with
 
 
-# ###############
-# Public
-# ###############
-
 func _get_init_text(meta, args, method_params, param_array):
 	var text = null
 
@@ -205,7 +133,7 @@ func _get_init_text(meta, args, method_params, param_array):
 			if(i != args.size() -1):
 				super_params += ', '
 
-	text = _init_text.format({
+	text = _init_template.format({
 		"func_decleration":decleration,
 		"super_params":super_params,
 		"param_array":param_array,
@@ -214,26 +142,22 @@ func _get_init_text(meta, args, method_params, param_array):
 
 	return text
 
+# ###############
+# Public
+# ###############
+
+
 
 # Creates a delceration for a function based off of function metadata.  All
 # types whose defaults are supported will have their values.  If a datatype
 # is not supported and the parameter has a default, a warning message will be
 # printed and the declaration will return null.
-func get_function_text(meta, singleton=null):
-	var method_params = ''
+func get_function_text(parsed_method, singleton=null):
+	var meta = parsed_method.meta
 	var text = null
-	var result = _make_arg_array(meta)
-	var has_unsupported = result[0]
-	var args = result[1]
-
+	var args = _make_arg_array(meta)
 	var param_array = _get_spy_call_parameters_text(args)
-	if(has_unsupported):
-		# This will cause a runtime error.  This is the most convenient way to
-		# to stop running before the error gets more obscure.  _make_arg_array
-		# generates a gut error when unsupported defaults are found.
-		method_params = null
-	else:
-		method_params = _get_arg_text(args);
+	var method_params = _get_arg_text(args);
 
 	if(param_array == 'null'):
 		param_array = '[]'
@@ -242,12 +166,17 @@ func get_function_text(meta, singleton=null):
 		if(meta.name == '_init'):
 			text =  _get_init_text(meta, args, method_params, param_array)
 		else:
+			var return_it = ''
+			if(parsed_method.return_type_text != 'void'):
+				return_it = 'return '
+
 			var decleration = str('func ', meta.name, '(', method_params, '):')
-			text = _func_text.format({
+			text = _func_template.format({
 				"func_decleration": decleration,
 				"method_name": meta.name,
 				"param_array": param_array,
-				"super_call": _get_super_call_text(meta, args, singleton),
+				"super_call": _get_super_call_text(parsed_method, singleton),
+				"return_it": return_it
 			})
 
 	return text
@@ -261,6 +190,3 @@ func set_logger(logger):
 	_lgr = logger
 
 
-func get_arg_text(meta):
-	var parsed = _make_arg_array(meta)
-	return _get_arg_text(parsed[1])

--- a/game/addons/gut/plugin.cfg
+++ b/game/addons/gut/plugin.cfg
@@ -3,5 +3,5 @@
 name="Gut"
 description="Unit Testing tool for Godot."
 author="Butch Wesley"
-version="9.6.0"
+version="9.7.0"
 script="gut_plugin.gd"

--- a/game/addons/gut/script_parser.gd
+++ b/game/addons/gut/script_parser.gd
@@ -3,16 +3,15 @@
 const BLACKLIST = [
 	'get_script',
 	'has_method',
+	'_to_string',
 ]
 
 
 # ------------------------------------------------------------------------------
-# Combins the meta for the method with additional information.
-# * flag for whether the method is local
-# * adds a 'default' property to all parameters that can be easily checked per
-#   parameter
+# Combines the meta for the method with additional information.
 # ------------------------------------------------------------------------------
 class ParsedMethod:
+
 	const NO_DEFAULT = '__no__default__'
 
 	var _meta = {}
@@ -21,7 +20,8 @@ class ParsedMethod:
 		set(val): return;
 
 	var is_local = false
-	var _parameters = []
+	var args = []
+	var return_type_text = 'void'
 
 	func _init(metadata):
 		_meta = metadata
@@ -34,7 +34,22 @@ class ParsedMethod:
 				arg['default'] = _meta.default_args[start_default - i]
 			else:
 				arg['default'] = NO_DEFAULT
-			_parameters.append(arg)
+			args.append(arg)
+
+		return_type_text = _get_return_type(metadata)
+
+	func _get_return_type(meta):
+		var r_meta = meta["return"]
+		var return_keyword = GutConstants.TYPE_KEYWORDS[r_meta.type]
+
+		if(r_meta.type != 0):
+			return_keyword = return_keyword
+		elif(r_meta.usage & PROPERTY_USAGE_NIL_IS_VARIANT != 0):
+			return_keyword = 'Variant'
+		else:
+			return_keyword = 'void'
+
+		return return_keyword
 
 
 	func is_eligible_for_doubling():
@@ -274,9 +289,12 @@ class ParsedScript:
 		return text
 
 
+
+
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
 var scripts = {}
+
 
 func _get_instance_id(thing):
 	var inst_id = null

--- a/game/addons/gut/singleton_parser.gd
+++ b/game/addons/gut/singleton_parser.gd
@@ -1,4 +1,5 @@
 class ParsedSingleton:
+
 	var methods_by_name = {}
 	var enums = {}
 	var properties = {}
@@ -14,7 +15,8 @@ class ParsedSingleton:
 		singleton_id = singleton.get_instance_id()
 
 		for method in ClassDB.class_get_method_list(sname, true):
-			methods_by_name[method.name] = method
+			var pm = GutUtils.ScriptCollector.ParsedMethod.new(method)
+			methods_by_name[method.name] = pm
 
 		for e in ClassDB.class_get_enum_list(sname, true):
 			for c in ClassDB.class_get_enum_constants(sname, e):

--- a/game/addons/gut/stub_params.gd
+++ b/game/addons/gut/stub_params.gd
@@ -10,7 +10,13 @@ var logger = _lgr :
 	set(val): _lgr = val
 
 
-var return_val = null
+var return_val = GutConstants.NOT_SET :
+	get():
+		if(GutConstants.is_not_set(return_val)):
+			return null
+		else:
+			return return_val
+var return_type = TYPE_NIL
 var stub_target = null
 var parameters = null # the parameter values to match method call on.
 var stub_method = null
@@ -66,12 +72,15 @@ func _init(target=null, method=null, _subpath=null):
 		_load_defaults_from_metadata(method)
 		is_script_default = true
 	elif(stub_target != null and stub_method != null and typeof(stub_target) != TYPE_STRING):
-		if(!GutUtils.is_native_class(stub_target)):
-			var method_list = stub_target.get_method_list()
-			if(method_list != null):
-				var meta = GutUtils.find_method_meta(method_list, stub_method)
-				if(meta != null):
-					_method_meta = meta
+		var method_list = null
+		if(typeof(stub_target) == TYPE_OBJECT and stub_target is GDScript):
+			method_list = stub_target.get_script_method_list()
+		elif(!GutUtils.is_native_class(stub_target)):
+			method_list = stub_target.get_method_list()
+		if(method_list != null):
+			var meta = GutUtils.find_method_meta(method_list, stub_method)
+			if(meta != null):
+				_method_meta = meta
 
 
 func _load_defaults_from_metadata(meta):
@@ -81,6 +90,8 @@ func _load_defaults_from_metadata(meta):
 		values.push_front(null)
 
 	param_defaults(values)
+	return_type = meta.return.type
+	return_val = GutConstants.get_default_return_value(meta.return.type)
 
 
 func _get_method_meta():
@@ -98,10 +109,29 @@ func _error_if_locked():
 	else:
 		return false
 
+func _is_return_value_valid(val):
+	var is_valid = true
+	var meta = _get_method_meta()
+	if((meta.return.type != 0 or (meta.return.type == 0 and !(meta.return.usage && PROPERTY_USAGE_NIL_IS_VARIANT))) and \
+		meta.return.type != typeof(return_val)):
+			is_valid = false
+	return is_valid
 
 # -------------------------
 # Public
 # -------------------------
+func validate() -> bool:
+	var meta = _get_method_meta()
+	var to_return = true
+
+	if(stub_method != '_init' and meta != {} and call_this == null):
+		if(!_is_return_value_valid(return_val)):
+			_lgr.error(str("Method [", stub_method, "] was stubbed to return invalid value [", return_val, "]."))
+			to_return = false
+
+	return to_return
+
+
 func to_return(val):
 	if(_error_if_locked()):
 		return
@@ -113,7 +143,9 @@ func to_return(val):
 
 
 func to_do_nothing():
-	to_return(null)
+	var meta = _get_method_meta()
+	if(meta != {}):
+		to_return(GutConstants.get_default_return_value(meta.return.type))
 	return self
 
 

--- a/game/addons/gut/stubber.gd
+++ b/game/addons/gut/stubber.gd
@@ -12,7 +12,7 @@ var _strutils = GutUtils.Strutils.new()
 var _stub_cache = []
 
 
-func _add_cache():
+func _flush_cache():
 	for stub_params in _stub_cache:
 		stub_params.logger = _lgr
 
@@ -22,6 +22,8 @@ func _add_cache():
 		if(!stub_params.is_default_override_only()):
 			action_stubs.add_stub(stub_params)
 
+		if(!stub_params.is_script_default):
+			stub_params.validate()
 		# lock the params so that any changes that would affect which bucket
 		# the params were put in can't be changed.
 		stub_params.locked = true
@@ -33,7 +35,7 @@ func _add_cache():
 #
 # obj can be an instance, class, or a path.
 func _find_action_stub(obj, method, parameters=null):
-	_add_cache()
+	_flush_cache()
 
 	var to_return = null
 	var matches = action_stubs.get_all_stubs(obj, method)
@@ -77,11 +79,6 @@ func _find_action_stub(obj, method, parameters=null):
 	elif(null_match != null):
 		to_return = null_match
 
-	# if(to_return != null):
-	# 	print("  USING ", to_return, ' = ', to_return.to_s())
-	# else:
-	# 	print("  USING null")
-
 	return to_return
 
 
@@ -114,8 +111,15 @@ func get_return(obj, method, parameters=null):
 	if(stub_info != null):
 		return stub_info.return_val
 	else:
-		_lgr.info(str('Call to [', method, '] was not stubbed for the supplied parameters ', parameters, '.  Null was returned.'))
-		return null
+		var default = parameter_stubs.get_default_stub(obj, method)
+		var to_return = null
+		if(default != null):
+			# This ensures that the values are unique and that any changes made
+			# to them in a test are not propigated to future calls of the same
+			# method.
+			to_return = GutConstants.get_default_return_value(default.return_type)
+		_lgr.info(str('Call to [', method, '] was not stubbed for the supplied parameters ', parameters, '.  [', to_return, '] was returned.'))
+		return to_return
 
 
 func should_call_super(obj, method, parameters=null):
@@ -146,7 +150,7 @@ func get_call_this(obj, method, parameters=null):
 
 
 func get_parameter_defaults(obj, method):
-	_add_cache()
+	_flush_cache()
 	var the_defaults = []
 	var script_defaults = []
 	var matches = parameter_stubs.get_all_stubs(obj, method)
@@ -190,8 +194,8 @@ func set_logger(logger):
 
 
 func to_s():
-	return str("Parameters:\n", parameter_stubs.to_s(),
-		"\nActions:\n" , action_stubs.to_s())
+	return str("Parameter Stubs:\n", parameter_stubs.to_s(),
+		"\nAction Stubs:\n" , action_stubs.to_s())
 
 
 func stub_defaults_from_meta(target, method_meta):

--- a/game/addons/gut/stubs.gd
+++ b/game/addons/gut/stubs.gd
@@ -15,7 +15,7 @@ func _normalize_stub_target(target):
 	var to_return = null
 	if(typeof(target) == TYPE_OBJECT or GutUtils.is_native_class(target)):
 		to_return = target
-	if(typeof(target) == TYPE_STRING):
+	elif(typeof(target) == TYPE_STRING):
 		if(FileAccess.file_exists(target)):
 			to_return = load(target)
 		else:
@@ -80,6 +80,18 @@ func get_all_stubs(thing, method):
 			matches.append_array(stubs[entry][method])
 	return matches
 
+
+func get_default_stub(thing, method):
+	var obj = _normalize_stub_target(thing)
+	var match_on = _get_entries_matching_target(obj)
+	var to_return = null
+	for entry in match_on:
+		if(stubs.has(entry) and stubs[entry].has(method)):
+			var method_stubs = stubs[entry][method]
+			for stub in method_stubs:
+				if(stub.is_script_default):
+					to_return = stub
+	return to_return
 
 func to_s():
 	var text = ''

--- a/game/addons/gut/summary.gd
+++ b/game/addons/gut/summary.gd
@@ -192,6 +192,15 @@ func get_totals(gut=_gut):
 	return totals
 
 
+func log_version_update(gut):
+	var ud = GutUtils.UpdateDetector.new()
+	ud.check_for_update()
+	var recommended = ud.get_gut_version_for_godot_version()
+	if(recommended != GutUtils.version_numbers.gut_version):
+		gut.get_logger().log(ud.get_update_string())
+	ud.free()
+	
+
 func log_end_run(gut=_gut):
 	var totals = get_totals(gut)
 	if(totals.tests == 0):
@@ -207,4 +216,5 @@ func log_end_run(gut=_gut):
 
 	_log_what_was_run(gut)
 	log_the_final_line(totals, gut)
+	log_version_update(gut)
 	lgr.log("")

--- a/game/addons/gut/test.gd
+++ b/game/addons/gut/test.gd
@@ -259,6 +259,9 @@ func _get_bad_method_message(inst, method_name, what_you_cant_do):
 		to_return = str("You cannot ", what_you_cant_do, " [", method_name, "] because the method does not exist.  ",
 			"This can happen if the method is virtual and not overloaded (i.e. _ready) ",
 			"or you have mistyped the name of the method.")
+	elif(GutUtils.ScriptCollector.BLACKLIST.has(method_name)):
+		to_return = str("Method '", method_name, "' cannot be stubbed because it ",
+			"is excluded by GUT when creating doubles.")
 	elif(!inst.__gutdbl_values.doubled_methods.has(method_name)):
 		to_return = str("You cannot ", what_you_cant_do, " [", method_name, "] because ",
 			_str(inst), ' does not overload it or it was ignored with ',
@@ -2086,9 +2089,7 @@ func assert_no_new_orphans(text=''):
 	var msg = ''
 	if(text != ''):
 		msg = ':  ' + text
-	# Note that get_counter will return -1 if the counter does not exist.  This
-	# can happen with a misplaced assert_no_new_orphans.  Checking for > 0
-	# ensures this will not cause some weird failure.
+
 	if(count > 0):
 		msg += str("\n", _strutils.indent_text(gut.get_orphan_counter().get_orphan_list_text(orphan_ids), 1, '    '))
 		_fail(str('Expected no orphans, but found ', count, msg))

--- a/game/addons/gut/update_detector.gd
+++ b/game/addons/gut/update_detector.gd
@@ -1,0 +1,346 @@
+extends Node
+## -----------------------------------------------------------------------------
+## Checks to see if there is a better version of GUT available for a version of
+## Godot.  The data used to validate the GUT version includes lower and upper
+## Godot versions
+##
+## There are 3 places where version information is located.
+##	* LOCAL_FILE_PATH:  This is the version information that is packed with this
+##	  release of GUT.  It serves as a fallback if remote data is not available.
+##	  This is most useful in detecting that GUT is being used with an earlier
+##	  release of Godot and remote data is not available.
+##	* REMOTE_FILE_URL:  This is where the the version information exists outside
+##	  of the local copy of GUT.  This data will be downlaoded to REMOTE_FILE_PATH
+##	  whenever remote data is fetched.
+##	* REMOTE_FILE_PATH: This is where REMOTE_FILE_URL is downloaded to.  When
+##	  the file is downloaded, timetamp information is added to the data so that
+##	  we can avoid downloading the file too often.  This file is used whenever
+##	  it exists.  If it does not exist and we don't fetch it, LOCAL_FILE_PATH
+##	  will be used.
+##
+## REMOTE_FILE_URL Location
+## Currently this file points to a file on the main branch.  This is the same
+## file that will be shipped with each version of GUT.  This allows the file to
+## be updated and still be shipped with each version of GUT.
+## -----------------------------------------------------------------------------
+var Vnt = load("res://addons/gut/version_numbers.gd").VerNumTools
+
+
+const REMOTE_FILE_URL = "https://api.github.com/repos/bitwes/gut/contents/addons/gut/versions.json"
+const LOCAL_FILE_PATH = "res://addons/gut/versions.json"
+const REMOTE_FILE_PATH = "user://gut_temp_directory/versions.json"
+const VERSION_ZERO = "0.0.0"
+
+class VersionData:
+	var _data := {}
+	var data_issues = []
+	const VERSION_ZERO = "0.0.0"
+
+	var Vnt = load("res://addons/gut/version_numbers.gd").VerNumTools
+
+
+	func is_gut_version_valid(gut_v, godot_v):
+		if(_data.releases.has(gut_v)):
+			var entry = _data.releases[gut_v]
+			return Vnt.is_version_gte(godot_v, entry.godot_min) and Vnt.is_version_lte(godot_v, entry.godot_max)
+		else:
+			return false
+
+
+	func parse_data(new_data):
+		data_issues.clear()
+		_data = {}
+		if(typeof(new_data) == TYPE_STRING):
+			_data = JSON.parse_string(new_data)
+		elif(typeof(new_data) == TYPE_DICTIONARY):
+			_data = new_data
+
+		if(!_data.has('asset_library')):
+			data_issues.append("asset_library entry missing")
+
+		if(_data.has('releases')):
+			for key in _data.releases:
+				var entry = _data.releases[key]
+				if(!entry.has('godot_min')):
+					data_issues.append(str(key, ' missing godot_min'))
+				if(!entry.has('godot_max')):
+					data_issues.append(str(key, ' missing godot_max'))
+		else:
+			data_issues.append('missing releases entry')
+
+		if(_data.has('branches')):
+			for key in _data.branches:
+				var entry = _data.branches[key]
+				if(!entry.has('godot_min')):
+					data_issues.append(str(key, ' missing godot_min'))
+				if(!entry.has('godot_max')):
+					data_issues.append(str(key, ' missing godot_max'))
+		else:
+			data_issues.append('missing branches entry')
+
+
+	func parse_file(path):
+		if(FileAccess.file_exists(path)):
+			var text = GutUtils.get_file_as_text(path)
+			parse_data(text)
+		else:
+			_data = {}
+
+
+	func get_gut_version_for_godot_version(godot_v=null):
+		var to_return = VERSION_ZERO
+		if(is_empty()):
+			return to_return
+
+		if(godot_v == null):
+			godot_v = GutUtils.version_numbers.make_godot_version_string()
+
+		for key in _data.releases:
+			var entry = _data.releases[key]
+			if(Vnt.is_version_gte(godot_v, entry.godot_min) and Vnt.is_version_lte(godot_v, entry.godot_max)):
+				if(Vnt.is_version_gte(key, to_return)):
+					to_return = key
+
+		if(to_return == VERSION_ZERO and _data.has('branches')):
+			for key in _data.branches:
+				var entry = _data.branches[key]
+				if(Vnt.is_version_gte(godot_v, entry.godot_min) and Vnt.is_version_lte(godot_v, entry.godot_max)):
+					to_return = key
+
+		return to_return
+
+	func is_empty():
+		return _data.is_empty()
+
+	func clear():
+		_data.clear()
+		data_issues.clear()
+
+	## See comment in get_update_string
+	# func is_in_asset_library(gut_v):
+	# 	if(_data.has('asset_library')):
+	# 		return _data.asset_library == gut_v
+	# 	else:
+	# 		return false
+
+	func get_data():
+		return _data.duplicate(true)
+
+
+var _http_request : HTTPRequest
+var local_data : VersionData = VersionData.new()
+var remote_data : VersionData = VersionData.new()
+
+var min_fetch_wait = 60 * 60 # 1 hour
+
+signal download_completed()
+signal updated()
+
+
+func _ready() -> void:
+	_setup_http_request(HTTPRequest.new())
+
+
+func _setup_http_request(request):
+	_http_request = request
+	add_child(_http_request)
+	_http_request.timeout = 3.0
+	_http_request.request_completed.connect(self._http_request_completed)
+
+
+func _write_remote_file(data):
+	data.fetch_timestamp = Time.get_unix_time_from_system()
+	GutUtils.write_file(REMOTE_FILE_PATH, JSON.stringify(data))
+
+
+func _url_formatter(url, link_text=null):
+	if(link_text == null):
+		return url
+	else:
+		return str(link_text, ':  ', url)
+
+
+#------------
+# Events
+#------------
+# Called when the HTTP request is completed.
+func _http_request_completed(result, response_code, headers, body):
+	var body_text = body.get_string_from_utf8()
+
+	if(response_code == 200):
+		var json = JSON.new()
+		var err = json.parse(body_text)
+		if(err != OK):
+			push_error("[GUT] Invalid JSON: ", json.get_error_message(), '.  ', body_text)
+			download_completed.emit()
+			return
+		var response = json.get_data()
+
+		remote_data.parse_data(response)
+		if(remote_data.data_issues.size() == 0):
+			_write_remote_file(response.duplicate(true))
+		else:
+			push_error("[GUT] Invalid version data:  ", remote_data.data_issues)
+			remote_data.clear()
+	else:
+		var json = JSON.new()
+		var err = json.parse(body_text)
+		var response = {}
+		if(err == OK):
+			response = json.get_data()
+
+		var msg = ''
+		if(response != null and response.has('message')):
+			msg = str(" (", response.message, ")")
+		push_error("[GUT] Could not get version info, response code:  ", response_code, msg)
+
+	download_completed.emit()
+
+
+func _is_branch_version(v : String):
+	return v.find(".") == -1
+#------------
+# Public
+#------------
+func fetch_remote_file():
+	var headers : PackedStringArray = [
+		"Accept: application/vnd.github.raw",
+		"X-GitHub-Api-Version: 2022-11-28"
+	]
+	var error = _http_request.request(REMOTE_FILE_URL, headers)
+	if error != OK:
+		var errtxt = str("[GUT] An error occurred requesting version data:  ", error, ".")
+		remote_data.data_issues.append(errtxt)
+		push_error(errtxt)
+	return error
+
+
+func get_gut_version_for_godot_version(godot_v=null):
+	var to_return = VERSION_ZERO
+	if(godot_v == null):
+		godot_v = GutUtils.version_numbers.make_godot_version_string()
+
+	var remote_latest = remote_data.get_gut_version_for_godot_version(godot_v)
+	var local_latest = local_data.get_gut_version_for_godot_version(godot_v)
+
+	if(remote_latest == VERSION_ZERO and local_latest != VERSION_ZERO):
+		to_return = local_latest
+	elif(remote_latest != VERSION_ZERO and local_latest == VERSION_ZERO):
+		to_return = remote_latest
+	elif(_is_branch_version(remote_latest) and !_is_branch_version(local_latest)):
+		to_return = local_latest
+	elif(Vnt.is_version_gte(remote_latest, local_latest)):
+		to_return = remote_latest
+	else:
+		to_return = local_latest
+
+	return to_return
+
+
+func is_gut_version_valid(gut_v =null, godot_v=null):
+	if(gut_v == null):
+		gut_v =  GutUtils.version_numbers.gut_version
+		godot_v =  GutUtils.version_numbers.make_godot_version_string()
+
+	if(!local_data.is_empty() and !remote_data.is_empty()):
+		return local_data.is_gut_version_valid(gut_v, godot_v) or \
+			remote_data.is_gut_version_valid(gut_v, godot_v)
+	else:
+		return true
+
+## See comment in get_update_string
+# func is_in_asset_library(gut_v):
+# 	if(remote_data._data.has('asset_library')):
+# 		return remote_data._data.asset_library == gut_v
+# 	else:
+# 		return false
+
+
+func check_for_update():
+	local_data.parse_file(LOCAL_FILE_PATH)
+	if(FileAccess.file_exists(REMOTE_FILE_PATH)):
+		remote_data.parse_file(REMOTE_FILE_PATH)
+
+	updated.emit.call_deferred()
+
+
+func check_for_update_with_fetch(force=false):
+	remote_data.parse_file(REMOTE_FILE_PATH)
+	var time_since_last_fetch = 60 * 60 * 24 * 10_000 # ten thousand days
+
+	if(remote_data._data.has("fetch_timestamp")):
+		time_since_last_fetch = Time.get_unix_time_from_system() - remote_data._data.fetch_timestamp
+
+	if(force or time_since_last_fetch > min_fetch_wait):
+		fetch_remote_file()
+		await download_completed
+
+	check_for_update()
+
+
+func get_update_string(url_formatter:Callable=_url_formatter):
+	var gut_v = GutUtils.version_numbers.gut_version
+	var godot_v = GutUtils.godot_version_string()
+	var version_info = str("GUT ", gut_v, " is the lastest version for Godot ", godot_v)
+
+	var rec_ver = get_gut_version_for_godot_version(godot_v)
+	var rec_ver_link = url_formatter.call(str("https://github.com/bitwes/Gut/releases/tag/v", rec_ver), str("GUT ",rec_ver))
+
+	if(is_gut_version_valid(gut_v, godot_v)):
+		if(rec_ver != gut_v):
+			version_info = str(rec_ver_link, ' is now available!')
+	else:
+		if(rec_ver.find(".") == -1):
+			version_info = str("GUT does not have a release for this version of Godot yet, but it does have ",
+			"the branch '", rec_ver, "'.\n",
+			"Check the readme for install links/instructions:  ", url_formatter.call('https://github.com/bitwes/Gut'))
+		else:
+			version_info = str('This version of GUT may not be compatible with Godot ', godot_v, '.  ')
+			if(rec_ver == '0.0.0'):
+				version_info += str("No release or branch exists for this version of Godot yet.  Check back soon.")
+			else:
+				version_info += str('Consider changing to ', rec_ver_link)
+	## Commented this out for now, this needs to be reassessed for the new store
+	## For now I'm leaving it out as I don't know what the urls look like or have
+	## anything out there yet.
+	# if(rec_ver != gut_v and is_in_asset_library(rec_ver)):
+	# 	version_info += str("\nYou can update to ", rec_ver, " through the Asset Library.")
+	return version_info
+
+
+func get_summary_string():
+	var gut_v = GutUtils.version_numbers.gut_version
+	var godot_v = GutUtils.godot_version_string()
+
+	return str("GUT:  ", gut_v, "\n",
+		"Godot:  ", godot_v, "\n",
+		"Valid:  ", is_gut_version_valid(gut_v, godot_v), "\n",
+		"Latest:  ", get_gut_version_for_godot_version(godot_v))
+
+
+func fetch_limit_wait_time():
+	var remaining = -1
+	if(remote_data.get_data().has("fetch_timestamp")):
+		var time_since_last_fetch = Time.get_unix_time_from_system() - remote_data._data.fetch_timestamp
+		return max(min_fetch_wait - time_since_last_fetch, 0.0)
+	else:
+		return -1
+
+
+func get_days_since_last_fetch():
+	var to_return = 99
+	if(remote_data.get_data().has("fetch_timestamp")):
+		var time_since_last_fetch = Time.get_unix_time_from_system() - remote_data._data.fetch_timestamp
+		to_return = time_since_last_fetch / (60.0 * 60.0 * 24.0)
+	return to_return
+
+
+func is_empty():
+	return local_data.is_empty() and remote_data.is_empty()
+
+
+func get_all_data():
+	return {
+		local_data:local_data.get_data(),
+		remote_data:remote_data.get_data()
+	}

--- a/game/addons/gut/utils.gd
+++ b/game/addons/gut/utils.gd
@@ -2,8 +2,6 @@
 class_name GutUtils
 extends Object
 
-const GUT_METADATA = '__gutdbl'
-
 # Note, these cannot change since places are checking for TYPE_INT to determine
 # how to process parameters.
 enum DOUBLE_STRATEGY{
@@ -15,6 +13,13 @@ enum DIFF {
 	DEEP,
 	SIMPLE
 }
+
+enum TREAT_AS {
+	NOTHING,
+	FAILURE,
+}
+
+const GUT_METADATA = '__gutdbl'
 
 const TEST_STATUSES = {
 	NO_ASSERTS = 'no asserts',
@@ -37,24 +42,27 @@ const NOTHING := '__NOTHING__'
 const NO_TEST := 'NONE'
 const GUT_ERROR_TYPE = 999
 
-enum TREAT_AS {
-	NOTHING,
-	FAILURE,
-}
 
-static var class_ref_by_name = {} :
+static var _class_ref_by_name := {}
+static var class_ref_by_name := {} :
 	get():
-		if(class_ref_by_name == {}):
-			class_ref_by_name = _create_class_dictionary()
-		return class_ref_by_name;
-
+		if(_class_ref_by_class == {}):
+			_create_class_dictionaries()
+		return _class_ref_by_name
+static var _class_ref_by_class := {}
+static var class_ref_by_class := {} :
+	get():
+		if(_class_ref_by_class == {}):
+			_create_class_dictionaries()
+		return _class_ref_by_class
 
 
 ## This dictionary defaults to all the native classes that we cannot call new
 ## on.  It is further populated during a run so that we only have to create
 ## a new instance once to get the class name string.
 static var gdscript_native_class_names_by_type = {
-	Tween:"Tween"
+	Tween:"Tween",
+	CanvasItem:"CanvasItem",
 }
 
 
@@ -194,16 +202,16 @@ static var TestCollector = LazyLoader.new('res://addons/gut/test_collector.gd'):
 static var ThingCounter = LazyLoader.new('res://addons/gut/thing_counter.gd'):
 	get: return ThingCounter.get_loaded()
 	set(val): pass
+static var UpdateDetector = LazyLoader.new('res://addons/gut/update_detector.gd'):
+	get: return UpdateDetector.get_loaded()
+	set(val): pass
 # --------------------------------
 
 static var gut_fonts = GutFonts.new()
 static var avail_fonts = gut_fonts.get_font_names()
 
 static var version_numbers = VersionNumbers.new(
-	# gut_versrion (source of truth)
-	'9.6.0',
-	# required_godot_version
-	'4.6'
+	'9.7.0' # gut_versrion (source of truth)
 )
 
 
@@ -249,17 +257,25 @@ static func get_error_tracker():
 #
 # This is lazy loaded into class_ref_by_name, it's only needed when finding
 # stubs.
-static func _create_class_dictionary():
+static func _create_class_dictionaries():
 	var text = "var all_the_classes: Dictionary = {\n"
 	var black_list = [
+		"IPUnix",
+		"GodotNavigationServer2D",
+		"NativeMenuMacOS",
 	]
 	for classname in ClassDB.get_class_list():
-		if(!black_list.has(classname) and (ClassDB.can_instantiate(classname) or GodotSingletons.names.has(classname))):
+		if(!black_list.has(classname) and (ClassDB.can_instantiate(classname) or \
+		 	GodotSingletons.names.has(classname))):
 			text += str('"', classname, '": ', classname, ", \n")
 
 	text += "}"
 	var inst =  GutUtils.create_script_from_source(text, 'res://dynamically_generated/class_dictionary.gd').new()
-	return inst.all_the_classes
+
+	_class_ref_by_name = inst.all_the_classes
+	for key in inst.all_the_classes:
+		_class_ref_by_class[inst.all_the_classes[key]] = key
+
 
 
 
@@ -314,14 +330,9 @@ static func make_install_check_text(template_paths=DOUBLE_TEMPLATES, ver_nums=ve
 		!FileAccess.file_exists(template_paths.SCRIPT)):
 
 		text = 'One or more GUT template files are missing.  If this is an exported project, you must include *.txt files in the export to run GUT.  If it is not an exported project then reinstall GUT.'
-	elif(!ver_nums.is_godot_version_valid()):
-		text = ver_nums.get_bad_version_text()
 
 	return text
 
-
-static func is_install_valid(template_paths=DOUBLE_TEMPLATES, ver_nums=version_numbers):
-	return make_install_check_text(template_paths, ver_nums) == INSTALL_OK_TEXT
 
 
 # ------------------------------------------------------------------------------
@@ -647,7 +658,12 @@ static func find_method_meta(methods, method_name):
 
 
 static func get_method_meta(object, method_name):
-	return find_method_meta(object.get_method_list(), method_name)
+	if(object is GDScript):
+		return find_method_meta(object.get_script_method_list(), method_name)
+	elif(is_native_class(object)):
+		return find_method_meta(ClassDB.class_get_method_list(class_ref_by_class[object]), method_name)
+	else:
+		return find_method_meta(object.get_method_list(), method_name)
 
 
 static func is_singleton(thing):

--- a/game/addons/gut/version_numbers.gd
+++ b/game/addons/gut/version_numbers.gd
@@ -12,7 +12,7 @@ class VerNumTools:
 		return parts
 
 
-	static func make_version_array(v):
+	static func make_version_array(v, min_spots=3):
 		var to_return = []
 		if(typeof(v) == TYPE_STRING):
 			to_return = _make_version_array_from_string(v)
@@ -20,6 +20,11 @@ class VerNumTools:
 			return [v.major, v.minor, v.patch]
 		elif(typeof(v) == TYPE_ARRAY):
 			to_return = v
+
+		if(to_return.size() < min_spots):
+			for i in range(min_spots - to_return.size()):
+				to_return.append(0)
+
 		return to_return
 
 
@@ -50,6 +55,24 @@ class VerNumTools:
 
 		# still null means each index was the same.
 		return GutUtils.nvl(is_ok, true)
+
+	static func is_version_lte(version, required):
+		var is_lt = null
+		var v = make_version_array(version)
+		var r = make_version_array(required)
+
+		var idx = 0
+
+		while(is_lt == null and idx < v.size() and idx < r.size()):
+			if(v[idx] < r[idx]):
+				is_lt = true
+			elif(v[idx] > r[idx]):
+				is_lt = false
+
+			idx += 1
+
+		# still null means each index was the same.
+		return GutUtils.nvl(is_lt, true)
 
 
 	static func is_version_eq(version, expected):
@@ -84,11 +107,10 @@ class VerNumTools:
 #
 # ##############################################################################
 var gut_version = '0.0.0'
-var required_godot_version = '0.0.0'
 
-func _init(gut_v = gut_version, required_godot_v = required_godot_version):
+func _init(gut_v = gut_version):
 	gut_version = gut_v
-	required_godot_version = required_godot_v
+
 
 
 # ------------------------------------------------------------------------------
@@ -99,23 +121,6 @@ func get_version_text():
 	var gut_version_info =  str('GUT version:  ', gut_version)
 	var godot_version_info  = str('Godot version:  ', v_info.major,  '.',  v_info.minor,  '.',  v_info.patch)
 	return godot_version_info + "\n" + gut_version_info
-
-
-# ------------------------------------------------------------------------------
-# Returns a nice string for erroring out when we have a bad Godot version.
-# ------------------------------------------------------------------------------
-func get_bad_version_text():
-	var info = Engine.get_version_info()
-	var gd_version = str(info.major, '.', info.minor, '.', info.patch)
-	return 'GUT ' + gut_version + ' requires Godot ' + required_godot_version + \
-		' or greater.  Godot version is ' + gd_version
-
-
-# ------------------------------------------------------------------------------
-# Checks the Godot version against required_godot_version.
-# ------------------------------------------------------------------------------
-func is_godot_version_valid():
-	return VerNumTools.is_version_gte(Engine.get_version_info(), required_godot_version)
 
 
 func make_godot_version_string():

--- a/game/addons/gut/versions.json
+++ b/game/addons/gut/versions.json
@@ -1,0 +1,31 @@
+{
+    "asset_library":"9.6.0",
+    "branches":{
+        "main":{
+            "godot_min":"4.6",
+            "godot_max":"4.6.999"
+        }
+    },
+    "releases":{
+        "9.7.0":{
+            "godot_min":"4.7",
+            "godot_max":"4.7.999"
+        },
+        "9.6.0":{
+            "godot_min":"4.6",
+            "godot_max":"4.6.999"
+        },
+        "9.5.0":{
+            "godot_min":"4.5",
+            "godot_max":"4.5.999"
+        },
+        "9.4.0":{
+            "godot_min":"4.3",
+            "godot_max":"4.4.999"
+        },
+        "9.3.0":{
+            "godot_min":"4.2",
+            "godot_max":"4.2.999"
+        }
+    }
+}

--- a/game/project.godot
+++ b/game/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Pendulum of Despair"
 run/main_scene="res://scenes/core/title.tscn"
-config/features=PackedStringArray("4.6", "GL Compatibility")
+config/features=PackedStringArray("4.7", "GL Compatibility")
 run/max_fps=60
 
 [autoload]

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "pendulum-of-despair",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "scripts": {
     "prepare": "husky"
   },
   "devDependencies": {
-    "@commitlint/cli": "^20.4.4",
-    "@commitlint/config-conventional": "^20.4.4",
+    "@commitlint/cli": "^21.1.0",
+    "@commitlint/config-conventional": "^21.1.0",
     "husky": "^9.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       '@commitlint/cli':
-        specifier: ^20.4.4
-        version: 20.4.4(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
+        specifier: ^21.1.0
+        version: 21.1.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
       '@commitlint/config-conventional':
-        specifier: ^20.4.4
-        version: 20.4.4
+        specifier: ^21.1.0
+        version: 21.1.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -95,74 +95,74 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
-  '@commitlint/cli@20.4.4':
-    resolution: {integrity: sha512-GLMNQHYGcn0ohL2HMlAnXcD1PS2vqBBGbYKlhrRPOYsWiRoLWtrewsR3uKRb9v/IdS+qOS0vqJQ64n1g8VPKFw==}
-    engines: {node: '>=v18'}
+  '@commitlint/cli@21.1.0':
+    resolution: {integrity: sha512-CVwY6TxGv5naEaWxBdgNHko1xgL95Mb4WcIqp9iik33H0ctVqRv6YtekCntayhEP0T/apuiGvHu5HcCwFuVxEA==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
-  '@commitlint/config-conventional@20.4.4':
-    resolution: {integrity: sha512-Usg+XXbPNG2GtFWTgRURNWCge1iH1y6jQIvvklOdAbyn2t8ajfVwZCnf5t5X4gUsy17BOiY+myszGsSMIvhOVA==}
-    engines: {node: '>=v18'}
+  '@commitlint/config-conventional@21.1.0':
+    resolution: {integrity: sha512-BIFl8xM+3SLy3jrblUC3wmQLCVbLty+++6o859BDCmybVrQdXmIWO+dlkGIbv/M2bBoC55wGuh0zGiw3TPjL1g==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/config-validator@20.4.4':
-    resolution: {integrity: sha512-K8hMS9PTLl7EYe5vWtSFQ/sgsV2PHUOtEnosg8k3ZQxCyfKD34I4C7FxWEfRTR54rFKeUYmM3pmRQqBNQeLdlw==}
-    engines: {node: '>=v18'}
+  '@commitlint/config-validator@21.1.0':
+    resolution: {integrity: sha512-gHczt1xqQSwfNqBmOI3HjejtTljkiBEUneExMmTBLD0WwTC78lAqDvNMyydbySt3DhpH0F9oX7Vvuks6s5XPFw==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/ensure@20.4.4':
-    resolution: {integrity: sha512-QivV0M1MGL867XCaF+jJkbVXEPKBALhUUXdjae66hes95aY1p3vBJdrcl3x8jDv2pdKWvIYIz+7DFRV/v0dRkA==}
-    engines: {node: '>=v18'}
+  '@commitlint/ensure@21.1.0':
+    resolution: {integrity: sha512-/S8Mo3Q1NtQUYDQjDmyQVPxfIwtnxq+guzMOkuGk8OSdwlzanm1WB9wDPIuuzlbMDDnBNbiAuBEUCcCNlfjrTQ==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/execute-rule@20.0.0':
-    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
-    engines: {node: '>=v18'}
+  '@commitlint/execute-rule@21.0.1':
+    resolution: {integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/format@20.4.4':
-    resolution: {integrity: sha512-jLi/JBA4GEQxc5135VYCnkShcm1/rarbXMn2Tlt3Si7DHiiNKHm4TaiJCLnGbZ1r8UfwDRk+qrzZ80kwh08Aow==}
-    engines: {node: '>=v18'}
+  '@commitlint/format@21.1.0':
+    resolution: {integrity: sha512-ySymqKYBfjNrQ5N4W/l1iF2ISW1W7Eu/Oi/wRxlri31N0yjNyzUyUzQwyuZLDzTXIlMs4IZ7hIOfAZx8lO18gA==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/is-ignored@20.4.4':
-    resolution: {integrity: sha512-y76rT8yq02x+pMDBI2vY4y/ByAwmJTkta/pASbgo8tldBiKLduX8/2NCRTSCjb3SumE5FBeopERKx3oMIm8RTQ==}
-    engines: {node: '>=v18'}
+  '@commitlint/is-ignored@21.1.0':
+    resolution: {integrity: sha512-RoRh1/YI+fYH+aid5lMQ2UD0vZ3p3Vf1KeUWT1ir3H/p/7T/6SFv1OiXLgLwUT8dP72EVWeEIyOfkiSWLZYVvw==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/lint@20.4.4':
-    resolution: {integrity: sha512-svOEW+RptcNpXKE7UllcAsV0HDIdOck9reC2TP1QA6K5Fo0xxQV+QPjV8Zqx9g6X/hQBkF2S9ZQZ78Xrv1Eiog==}
-    engines: {node: '>=v18'}
+  '@commitlint/lint@21.1.0':
+    resolution: {integrity: sha512-0DbfVVUjAWBfixW6v7CXXWVxMcj6Ukf/oB7O8NAbouP3jxmqUaC4eVQphxl3B3M0ii3cCQiR3sRAYxICwU2gAA==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/load@20.4.4':
-    resolution: {integrity: sha512-kvFrzvoIACa/fMjXEP0LNEJB1joaH3q3oeMJsLajXE5IXjYrNGVcW1ZFojXUruVJ7odTZbC3LdE/6+ONW4f2Dg==}
-    engines: {node: '>=v18'}
+  '@commitlint/load@21.1.0':
+    resolution: {integrity: sha512-juiClVEcoreNB0TNVkseO2EmNcpEs/Yhnmgbnm/hQAKBFRynKwIaoNIljXkx/3yvZcMO0EE8I2XOEI7d5KZG8Q==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/message@20.4.3':
-    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
-    engines: {node: '>=v18'}
+  '@commitlint/message@21.0.2':
+    resolution: {integrity: sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/parse@20.4.4':
-    resolution: {integrity: sha512-AjfgOgrjEozeQNzhFu1KL5N0nDx4JZmswVJKNfOTLTUGp6xODhZHCHqb//QUHKOzx36If5DQ7tci2o7szYxu1A==}
-    engines: {node: '>=v18'}
+  '@commitlint/parse@21.1.0':
+    resolution: {integrity: sha512-HdAqbbjQS8eEtbR74Ysg2VNmbvAfeWLVYMkip/lHibNrtjRsC/97XAYN3/H5P0pEJtDfyTb3iLs8x6y0eu4OYA==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/read@20.4.4':
-    resolution: {integrity: sha512-jvgdAQDdEY6L8kCxOo21IWoiAyNFzvrZb121wU2eBxI1DzWAUZgAq+a8LlJRbT0Qsj9INhIPVWgdaBbEzlF0dQ==}
-    engines: {node: '>=v18'}
+  '@commitlint/read@21.1.0':
+    resolution: {integrity: sha512-ID7m79aw8d0dMlxuXHD2QGxEX3Fhl/mUPA80WwEW5VgeOpUHNahhwWJefDdoBDVZcDfbHuf429NrcK0gxQsQjA==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/resolve-extends@20.4.4':
-    resolution: {integrity: sha512-pyOf+yX3c3m/IWAn2Jop+7s0YGKPQ8YvQaxt9IQxnLIM3yZAlBdkKiQCT14TnrmZTkVGTXiLtckcnFTXYwlY0A==}
-    engines: {node: '>=v18'}
+  '@commitlint/resolve-extends@21.1.0':
+    resolution: {integrity: sha512-SANYkxJDfMl3TvnyALWHEaiF5nc6FFaOnh7VvfxjT4X2vD4i2gVHhmfMm1fsrBwDRX98/XyM1XDo5sAd/KXcyQ==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/rules@20.4.4':
-    resolution: {integrity: sha512-PmUp8QPLICn9w05dAx5r1rdOYoTk7SkfusJJh5tP3TqHwo2mlQ9jsOm8F0HSXU9kuLfgTEGNrunAx/dlK/RyPQ==}
-    engines: {node: '>=v18'}
+  '@commitlint/rules@21.1.0':
+    resolution: {integrity: sha512-fOPEYSmKn1ZJptjLmCEjJfYqz0PUYr8ng6VY2ZW26sB7KtENR90CmAXHEmScBbOIZip+d/+OwqK12DFBuHTqsQ==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/to-lines@20.0.0':
-    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
-    engines: {node: '>=v18'}
+  '@commitlint/to-lines@21.0.1':
+    resolution: {integrity: sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/top-level@20.4.3':
-    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
-    engines: {node: '>=v18'}
+  '@commitlint/top-level@21.0.2':
+    resolution: {integrity: sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==}
+    engines: {node: '>=22.12.0'}
 
-  '@commitlint/types@20.4.4':
-    resolution: {integrity: sha512-dwTGzyAblFXHJNBOgrTuO5Ee48ioXpS5XPRLLatxhQu149DFAHUcB3f0Q5eea3RM4USSsP1+WVT2dBtLVod4fg==}
-    engines: {node: '>=v18'}
+  '@commitlint/types@21.1.0':
+    resolution: {integrity: sha512-YodnnnH1Cp+08nP8HGNJAIuB6L3/vdCTHVRTfF8Ik/wRCLOTsU9zwv3yO1cSPQRDa9CLYtE+UJ2K67r7CwMSFw==}
+    engines: {node: '>=22.12.0'}
 
   '@conventional-changelog/git-client@2.6.0':
     resolution: {integrity: sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==}
@@ -569,13 +569,13 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -624,16 +624,9 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -743,8 +736,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -775,6 +768,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -862,6 +858,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -876,11 +876,12 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
-  global-directory@4.0.1:
-    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
-    engines: {node: '>=18'}
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -915,15 +916,12 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-meta-resolve@4.2.0:
-    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -935,10 +933,6 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
@@ -1055,9 +1049,6 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -1076,23 +1067,8 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
-  lodash.kebabcase@4.1.1:
-    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
-
-  lodash.mergewith@4.6.2:
-    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
-
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-
-  lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-
-  lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  lodash.upperfirst@4.3.1:
-    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1137,9 +1113,6 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1218,10 +1191,6 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
-
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1302,13 +1271,13 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
@@ -1448,9 +1417,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1459,13 +1428,13 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
 snapshots:
 
@@ -1477,116 +1446,111 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@commitlint/cli@20.4.4(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.1.0(@types/node@25.5.0)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
     dependencies:
-      '@commitlint/format': 20.4.4
-      '@commitlint/lint': 20.4.4
-      '@commitlint/load': 20.4.4(@types/node@25.5.0)(typescript@5.9.3)
-      '@commitlint/read': 20.4.4(conventional-commits-parser@6.3.0)
-      '@commitlint/types': 20.4.4
+      '@commitlint/config-conventional': 21.1.0
+      '@commitlint/format': 21.1.0
+      '@commitlint/lint': 21.1.0
+      '@commitlint/load': 21.1.0(@types/node@25.5.0)(typescript@5.9.3)
+      '@commitlint/read': 21.1.0(conventional-commits-parser@6.3.0)
+      '@commitlint/types': 21.1.0
       tinyexec: 1.0.4
-      yargs: 17.7.2
+      yargs: 18.0.0
     transitivePeerDependencies:
       - '@types/node'
       - conventional-commits-filter
       - conventional-commits-parser
       - typescript
 
-  '@commitlint/config-conventional@20.4.4':
+  '@commitlint/config-conventional@21.1.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 21.1.0
       conventional-changelog-conventionalcommits: 9.3.0
 
-  '@commitlint/config-validator@20.4.4':
+  '@commitlint/config-validator@21.1.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 21.1.0
       ajv: 8.18.0
 
-  '@commitlint/ensure@20.4.4':
+  '@commitlint/ensure@21.1.0':
     dependencies:
-      '@commitlint/types': 20.4.4
-      lodash.camelcase: 4.3.0
-      lodash.kebabcase: 4.1.1
-      lodash.snakecase: 4.1.1
-      lodash.startcase: 4.4.0
-      lodash.upperfirst: 4.3.1
+      '@commitlint/types': 21.1.0
+      es-toolkit: 1.49.0
 
-  '@commitlint/execute-rule@20.0.0': {}
+  '@commitlint/execute-rule@21.0.1': {}
 
-  '@commitlint/format@20.4.4':
+  '@commitlint/format@21.1.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 21.1.0
       picocolors: 1.1.1
 
-  '@commitlint/is-ignored@20.4.4':
+  '@commitlint/is-ignored@21.1.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 21.1.0
       semver: 7.7.4
 
-  '@commitlint/lint@20.4.4':
+  '@commitlint/lint@21.1.0':
     dependencies:
-      '@commitlint/is-ignored': 20.4.4
-      '@commitlint/parse': 20.4.4
-      '@commitlint/rules': 20.4.4
-      '@commitlint/types': 20.4.4
+      '@commitlint/is-ignored': 21.1.0
+      '@commitlint/parse': 21.1.0
+      '@commitlint/rules': 21.1.0
+      '@commitlint/types': 21.1.0
 
-  '@commitlint/load@20.4.4(@types/node@25.5.0)(typescript@5.9.3)':
+  '@commitlint/load@21.1.0(@types/node@25.5.0)(typescript@5.9.3)':
     dependencies:
-      '@commitlint/config-validator': 20.4.4
-      '@commitlint/execute-rule': 20.0.0
-      '@commitlint/resolve-extends': 20.4.4
-      '@commitlint/types': 20.4.4
+      '@commitlint/config-validator': 21.1.0
+      '@commitlint/execute-rule': 21.0.1
+      '@commitlint/resolve-extends': 21.1.0
+      '@commitlint/types': 21.1.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
       cosmiconfig-typescript-loader: 6.2.0(@types/node@25.5.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      es-toolkit: 1.49.0
       is-plain-obj: 4.1.0
-      lodash.mergewith: 4.6.2
       picocolors: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
       - typescript
 
-  '@commitlint/message@20.4.3': {}
+  '@commitlint/message@21.0.2': {}
 
-  '@commitlint/parse@20.4.4':
+  '@commitlint/parse@21.1.0':
     dependencies:
-      '@commitlint/types': 20.4.4
+      '@commitlint/types': 21.1.0
       conventional-changelog-angular: 8.3.0
       conventional-commits-parser: 6.3.0
 
-  '@commitlint/read@20.4.4(conventional-commits-parser@6.3.0)':
+  '@commitlint/read@21.1.0(conventional-commits-parser@6.3.0)':
     dependencies:
-      '@commitlint/top-level': 20.4.3
-      '@commitlint/types': 20.4.4
+      '@commitlint/top-level': 21.0.2
+      '@commitlint/types': 21.1.0
       git-raw-commits: 5.0.1(conventional-commits-parser@6.3.0)
-      minimist: 1.2.8
       tinyexec: 1.0.4
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@commitlint/resolve-extends@20.4.4':
+  '@commitlint/resolve-extends@21.1.0':
     dependencies:
-      '@commitlint/config-validator': 20.4.4
-      '@commitlint/types': 20.4.4
-      global-directory: 4.0.1
-      import-meta-resolve: 4.2.0
-      lodash.mergewith: 4.6.2
+      '@commitlint/config-validator': 21.1.0
+      '@commitlint/types': 21.1.0
+      es-toolkit: 1.49.0
+      global-directory: 5.0.0
       resolve-from: 5.0.0
 
-  '@commitlint/rules@20.4.4':
+  '@commitlint/rules@21.1.0':
     dependencies:
-      '@commitlint/ensure': 20.4.4
-      '@commitlint/message': 20.4.3
-      '@commitlint/to-lines': 20.0.0
-      '@commitlint/types': 20.4.4
+      '@commitlint/ensure': 21.1.0
+      '@commitlint/message': 21.0.2
+      '@commitlint/to-lines': 21.0.1
+      '@commitlint/types': 21.1.0
 
-  '@commitlint/to-lines@20.0.0': {}
+  '@commitlint/to-lines@21.0.1': {}
 
-  '@commitlint/top-level@20.4.3':
+  '@commitlint/top-level@21.0.2':
     dependencies:
       escalade: 3.2.0
 
-  '@commitlint/types@20.4.4':
+  '@commitlint/types@21.1.0':
     dependencies:
       conventional-commits-parser: 6.3.0
       picocolors: 1.1.1
@@ -1904,11 +1868,9 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-regex@5.0.1: {}
+  ansi-regex@6.2.2: {}
 
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -1954,17 +1916,11 @@ snapshots:
 
   chai@6.2.2: {}
 
-  cliui@8.0.1:
+  cliui@9.0.1:
     dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   combined-stream@1.0.8:
     dependencies:
@@ -2056,7 +2012,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  emoji-regex@8.0.0: {}
+  emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
 
@@ -2082,6 +2038,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -2210,6 +2168,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2240,9 +2200,9 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  global-directory@4.0.1:
+  global-directory@5.0.0:
     dependencies:
-      ini: 4.1.1
+      ini: 6.0.0
 
   gopd@1.2.0: {}
 
@@ -2275,19 +2235,15 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-meta-resolve@4.2.0: {}
-
   inherits@2.0.4: {}
 
-  ini@4.1.1: {}
+  ini@6.0.0: {}
 
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
-
-  is-fullwidth-code-point@3.0.0: {}
 
   is-obj@2.0.0: {}
 
@@ -2382,8 +2338,6 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lodash.camelcase@4.3.0: {}
-
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -2396,17 +2350,7 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
-  lodash.kebabcase@4.1.1: {}
-
-  lodash.mergewith@4.6.2: {}
-
   lodash.once@4.1.1: {}
-
-  lodash.snakecase@4.1.1: {}
-
-  lodash.startcase@4.4.0: {}
-
-  lodash.upperfirst@4.3.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2435,8 +2379,6 @@ snapshots:
       mime-db: 1.54.0
 
   mime@2.6.0: {}
-
-  minimist@1.2.8: {}
 
   ms@2.1.3: {}
 
@@ -2506,8 +2448,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-
-  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -2619,15 +2559,15 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  string-width@4.2.3:
+  string-width@7.2.0:
     dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
-  strip-ansi@6.0.1:
+  strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 5.0.1
+      ansi-regex: 6.2.2
 
   superagent@10.3.0:
     dependencies:
@@ -2735,24 +2675,23 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@7.0.0:
+  wrap-ansi@9.0.2:
     dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@22.0.0: {}
 
-  yargs@17.7.2:
+  yargs@18.0.0:
     dependencies:
-      cliui: 8.0.1
+      cliui: 9.0.1
       escalade: 3.2.0
       get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
+      string-width: 7.2.0
       y18n: 5.0.8
-      yargs-parser: 21.1.1
+      yargs-parser: 22.0.0


### PR DESCRIPTION
## Summary

Two-month dependency refresh — bumps every pinned dependency surface to latest.

- **Engine:** Godot `4.6.2` → **`4.7`** (`project.godot` features flag + CI `GODOT_VERSION`). GUT addon `9.6.0` → **`9.7.0`**, which upstream ships specifically for Godot 4.7 compatibility.
- **Tooling:** `@commitlint/cli` + `@commitlint/config-conventional` `20.4.4` → **`21.1.0`**; pnpm `10.32.1` → **`11.9.0`** (`packageManager` pin via corepack, lockfile regenerated). `husky` already at latest `9.1.7`.
- **CI:** `actions/checkout@v4` → **`@v6`** in `gut-tests.yml` (the only workflow still on v4).
- **Node:** `.naverc` already targets latest LTS via the `lts` alias (resolves to Node 24) — no change needed; it satisfies the new engine floors (commitlint 21 ≥ 22.12, pnpm 11 ≥ 22.13).

## Type

- [ ] feat — New functionality
- [ ] fix — Bug fix
- [ ] refactor — Code change that neither fixes a bug nor adds a feature
- [x] chore — Tooling, deps, CI, config
- [ ] docs — Documentation only
- [ ] test — Adding or updating tests

## Test Plan

- [x] Manual testing (described below)

Verified locally against installed **Godot 4.6.2** (the highest available locally) with the new **GUT 9.7.0** addon:

- `godot --headless --path game/ --import` → exit 0
- Full GUT suite: **862 tests / 52 scripts / 2955 asserts — all passing** (also re-run automatically by the pre-push hook)
- `commitlint` v21 validates conventional messages (valid passes, malformed rejected; the `commit-msg` hook caught an over-length body during this PR's own commit)
- `pnpm install` clean under pnpm 11; lockfile stays `lockfileVersion: 9.0`

## Notes

⚠️ **Godot 4.7 engine behavior is verified by CI only.** My local editor is 4.6.2, so the 862-test pass above ran on the 4.6 engine. The one residual risk is GUT 9.7.0's documented breaking change: under Godot 4.7's stricter return-type checking, stubbed test **doubles now return a type-default instead of `null`**, which can flip results in tests that relied on the old null behavior. The `GUT Tests` workflow downloads real Godot 4.7 and is the gate for this — **do not merge until that check is green.**

- `scripts/requirements.txt` (`curl_cffi`, `html2text`, `lxml`) is intentionally left unpinned — it already resolves to latest on install, and these are utility-script deps unrelated to the game build. Adding pins would be a new constraint, not an update.
- The `claude.yml` / `claude-code-review.yml` review-prompt strings still describe the pre-Godot tech stack (Phaser/Vite/TS monorepo). These are prompt context, not version pins, so they're out of scope here — flagging as a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
