### PR TITLE
feat(engine): battle Magic submenu + ATB config (Bundle 1: GAP-001, GAP-007)

### DIFF
--- a/docs/decisions/2026-06-27-bundle1-push-blocked-godot-import-wedge.md
+++ b/docs/decisions/2026-06-27-bundle1-push-blocked-godot-import-wedge.md
@@ -1,0 +1,147 @@
+# 2026-06-27: Bundle 1 Push Blocked — Godot Import U-State Wedge
+
+**Date:** 2026-06-27  
+**Status:** ✅ RESOLVED — reboot cleared the wedge; Bundle 1 pushed as **PR #241**.
+**Decision:** Document local environment blocker and contingency options before machine reboot.
+
+---
+
+## Summary
+
+**Bundle 1** (GAP-001 Magic submenu + GAP-007 ATB config) is **fully implemented, tested (gdlint/gdformat clean), and committed locally** at `b6d8ec1` on branch `feature/combat-command-core`.
+
+However, **the push to origin is blocked** by a recurring macOS environment deadlock: the Godot 4.7 import process wedges in uninterruptible U-state during the pre-push hook, preventing the test suite from completing.
+
+This is **environmental, not a code issue.** The code is safe and ready.
+
+---
+
+## Bundle 1 Implementation
+
+### GAP-001: Magic Command (Submenu Population)
+
+**What was broken:** The Magic command opened an empty submenu. The `_show_submenu()` method existed but nothing ever populated it via `set_submenu_items()`.
+
+**What was fixed:**
+- Added spell-helper preload to `battle_command_menu.gd`
+- Implemented `_build_magic_submenu()` to fetch the caster's known spells from `spell_helpers.get_known_spells(character_id, level)`
+- Wired the Magic branch to build and show the submenu with spell names, MP costs, and greyed-out unavailable spells
+- Updated `battle_ui.gd` to pass the caster's current MP data to the menu
+
+**Key fix discovered during ultrathink pass:** The planning agents caught that `battle_command_menu` was reading `character_data["id"]`, but live battles use `"character_id"`. This bug was masked by unit tests using synthetic shapes. Tests now use the real `character_id` key shape.
+
+**Testing:** New `test_battle_command_menu.gd` with 5 unit tests covering spell-list generation, MP filtering, and character-data shape compatibility.
+
+### GAP-007: ATB Config Propagation
+
+**What was broken:** Player config (ATB Mode, Battle Speed, Patience Mode) was read from `PartyState` but never applied to the battle engine. Battles always ran in "active" mode with speed 3.
+
+**What was fixed:**
+- Added unit-tested static helper `ATBSystem.settings_from_config()` that maps player config to ATB engine mode/speed (testable, reusable)
+- Wired `battle_manager._ready()` to call the helper and apply config to `$ATBSystem`
+- Verified all three config keys exist and pass through to combat
+
+**Testing:** New tests in `test_atb_system.gd` covering the config-mapping helper.
+
+---
+
+## Safe Local State
+
+- **Branch:** `feature/combat-command-core`
+- **Commit:** `b6d8ec1` (Bundle 1 complete, committed)
+- **Remote status:** Not yet pushed to origin
+- **Quality gates:** 
+  - gdlint: ✅ pass
+  - gdformat: ✅ pass
+  - Pre-push data-integrity scans: ✅ pass (ID uniqueness, stale counts, scene refs all clean)
+  - Pre-push test suite: ⚠️ **blocked by Godot import wedge** (not yet run, but planned tests are green locally)
+
+---
+
+## The Blocker: Godot Import U-State Wedge
+
+**Symptom:** When the pre-push hook attempts to import Godot 4.7 for the test suite, the process hangs in **uninterruptible U-state** (0% CPU, cannot be killed, blocking all further process execution).
+
+**Root cause:** macOS environment deadlock — likely accumulated from repeated import attempts during this session. A clean boot reliably resolves U-state deadlocks.
+
+**Verification:** Pre-push hook successfully completed ID-uniqueness, stale-count, and scene-reference integrity scans (all clean), then hung on the Godot import. The import itself is working upstream (CI on Linux is unaffected).
+
+---
+
+## Three Options
+
+### Option 1: Reboot, Then Push ✅ **Recommended**
+1. Reboot the machine
+2. On return, run `git push -u origin feature/combat-command-core`
+3. The pre-push hook will run the full test suite on a clean environment (reliably succeeds)
+4. Once pushed, create the PR
+
+**Why:** This is the clean path. It guarantees the pre-push gate runs and passes before the code lands on origin.
+
+### Option 2: Authorize `--no-verify` Push with CI as Gate
+1. You explicitly authorize skipping the pre-push hook
+2. Run `git push -u origin feature/combat-command-core --no-verify`
+3. The code lands on origin without local test verification
+4. **Rely on CI (Linux Godot 4.7 on GitHub Actions)** as the test gate
+
+**Why:** This trades the local gate for CI. The code is safe (gdlint/gdformat clean, planning pass validated the approach).
+
+**Cons:** Skips the local test gate on real game code. Only acceptable if you explicitly approve it (same trade you okayed for beads PRs).
+
+### Option 3: Wait for Intermittent Wedge to Drain
+1. Let the U-state process remain blocked
+2. Retry the push later (wedge intermittently drains after 10–20 minutes)
+
+**Why:** No action required; sometimes it clears on its own.
+
+**Cons:** Unpredictable; may take hours. Not recommended.
+
+---
+
+## Decision
+
+**Proceeded with Option 1 (reboot-and-push).**
+
+### Resolution (2026-06-27)
+
+The machine was rebooted; the import wedge cleared (`--headless --import` now
+completes in ~3s). Pushing then ran the full pre-push GUT suite **for the first
+time** and surfaced **5 real failures** in the new `test_battle_command_menu.gd`
+that the wedge had been masking the whole time:
+
+- The menu's three `@onready` child refs (`$CommandList`, `$SubMenu`,
+  `$SubMenu/SubMenuList`) used `$` shorthand, which is `get_node()` — it emits a
+  "node not found → nullptr" **engine error** when the menu is instantiated via
+  `.new()` in a unit test (no scene children). That's 3 errors × 5 tests, and
+  GUT counts unexpected engine errors as failures.
+- **Fix:** switched the three refs to `get_node_or_null` (commit `e9669f4`).
+  Every use of these refs was already null-guarded, so `battle.tscn` is
+  unaffected — only the no-children unit-test path changes.
+
+Suite is now **924/924 green** through the pre-push gate. Branch pushed and
+opened as **PR #241** (`feature/combat-command-core` → `main`).
+
+**Lesson:** a wedged pre-push hook means real game-code tests are *not* running
+locally — never treat "gates pass except the import" as "tests are green."
+
+---
+
+## Next Steps After Bundle 1 Lands
+
+Once Bundle 1 is merged to `main`:
+
+### Bundle 2: Combat Resolution Layer (Status + Type-Traits + Cael + Abilities Epic)
+- **GAP-003:** Status infliction (poison ticks, frozen state, resist rolls)
+- **GAP-008:** Enemy type-trait multipliers (fire → undead, water → earth, etc.)
+- **GAP-010:** Cael data-driven stat spike (replaces hardcoded +10% with design mandated +2 ATK / +2 MAG / +1 SPD)
+- **GAP-002:** Six unique character commands (Bulwark, Rally, Forgewave, etc.) — the ability epic
+
+These are grouped because they all touch `damage_calculator`'s signature, the combat-resolution path, and share test infrastructure.
+
+---
+
+## References
+
+- **GAP-001 issue:** `docs/issues/GAP-001-magic-command-is-non-functional-in-battle-spell-su.md`
+- **GAP-007 issue:** `docs/issues/GAP-007-atb-mode-battle-speed-patience-mode-config-never-r.md`
+- **Gap analysis tracker:** `gh issue list --label gap-analysis`

--- a/game/scripts/combat/atb_system.gd
+++ b/game/scripts/combat/atb_system.gd
@@ -99,6 +99,16 @@ func set_atb_mode(mode: String) -> void:
 	_atb_mode = mode
 
 
+## Derive the effective ATB mode + battle speed from the player's config (GAP-007).
+## Patience Mode (accessibility) takes precedence, pausing gauges during the
+## command menu as well as submenus. Pure/static so it can be unit-tested.
+static func settings_from_config(config: Dictionary) -> Dictionary:
+	var mode: String = str(config.get("atb_mode", "active"))
+	if bool(config.get("patience_mode", false)):
+		mode = "patience"
+	return {"mode": mode, "speed": int(config.get("battle_speed", 3))}
+
+
 func set_submenu_open(is_open: bool) -> void:
 	_submenu_open = is_open
 

--- a/game/scripts/combat/battle_manager.gd
+++ b/game/scripts/combat/battle_manager.gd
@@ -13,6 +13,7 @@ signal message(text: String)
 
 const DamageCalc = preload("res://scripts/combat/damage_calculator.gd")
 const BattleActions = preload("res://scripts/combat/battle_actions.gd")
+const ATBSystem = preload("res://scripts/combat/atb_system.gd")
 const ENEMY_SCENE: PackedScene = preload("res://scenes/entities/enemy.tscn")
 
 var _return_map_id: String = ""
@@ -75,6 +76,7 @@ func _ready() -> void:
 		return
 	_setup_party()
 	_setup_enemies(encounter_group, data.get("enemy_act", "act_i"))
+	_apply_atb_config()
 	_atb.apply_formation(_formation_type)
 	if _formation_type == "back_attack":
 		for i: int in range(4):
@@ -90,6 +92,15 @@ func _ready() -> void:
 		es.append({"name": e.get_display_name(), "hp": e.current_hp})
 		pos.append(e.position)
 	battle_started.emit(ps, es, pos)
+
+
+## Apply the player's ATB Mode / Battle Speed / Patience Mode config to the
+## ATB system at battle start (GAP-007). Without this the player's settings
+## never reached combat and the gauges always ran in "active" mode at speed 3.
+func _apply_atb_config() -> void:
+	var settings: Dictionary = ATBSystem.settings_from_config(PartyState.get_config())
+	_atb.set_atb_mode(str(settings.get("mode", "active")))
+	_atb.set_battle_speed(int(settings.get("speed", 3)))
 
 
 func _process(delta: float) -> void:

--- a/game/scripts/ui/battle_command_menu.gd
+++ b/game/scripts/ui/battle_command_menu.gd
@@ -9,6 +9,8 @@ signal target_changed(index: int, is_enemy: bool)
 
 enum MenuState { HIDDEN, COMMAND, SUBMENU, TARGET }
 
+const SpellHelpers := preload("res://scripts/ui/spell_helpers.gd")
+
 const COLOR_SELECTED: Color = Color("#ffff88")
 const COLOR_NORMAL: Color = Color("#ccddff")
 const COLOR_DISABLED: Color = Color("#666688")
@@ -23,6 +25,8 @@ var _target_cursor: int = 0
 var _target_is_enemy: bool = true
 var _pending_command: Dictionary = {}
 var _target_count: int = 0
+var _character_data: Dictionary = {}
+var _current_mp: int = 0
 
 @onready var _command_list: VBoxContainer = $CommandList
 @onready var _submenu: PanelContainer = $SubMenu
@@ -36,8 +40,11 @@ func _ready() -> void:
 
 
 ## Show command menu for a party member.
-func show_commands(character_data: Dictionary, is_boss: bool) -> void:
+## current_mp drives MP affordability greying in the Magic submenu.
+func show_commands(character_data: Dictionary, is_boss: bool, current_mp: int = 0) -> void:
 	_is_boss = is_boss
+	_character_data = character_data
+	_current_mp = current_mp
 	_cursor = 0
 	_state = MenuState.COMMAND
 
@@ -178,6 +185,7 @@ func _confirm_command() -> void:
 			_pending_command = {"type": "attack"}
 			_start_target_selection(true)
 		"magic":
+			_build_magic_submenu()
 			_show_submenu()
 		"ability":
 			_show_submenu()
@@ -227,6 +235,34 @@ func _confirm_submenu() -> void:
 			hide_menu()
 		_:
 			_start_target_selection(true)
+
+
+## Populate the submenu with the active character's known spells (GAP-001).
+## Each item routes a {"type": "magic", "spell": <spell_dict>} command; spells
+## the character cannot afford are disabled. Mirrors menu_magic's data access.
+func _build_magic_submenu() -> void:
+	# Live battle character_data uses key "character_id" (PartyState member shape);
+	# fall back to "id" (raw character JSON shape) for safety.
+	var char_id: String = _character_data.get("character_id", _character_data.get("id", ""))
+	var level: int = int(_character_data.get("level", 1))
+	var items: Array[Dictionary] = []
+	for spell_v: Variant in SpellHelpers.get_known_spells(char_id, level):
+		if not spell_v is Dictionary:
+			continue
+		var spell: Dictionary = spell_v
+		var cost: int = int(spell.get("mp_cost", 0))
+		(
+			items
+			. append(
+				{
+					"label": "%s  %d MP" % [spell.get("name", "Spell"), cost],
+					"command": {"type": "magic", "spell": spell},
+					"target_type": spell.get("target", "single_enemy"),
+					"enabled": _current_mp >= cost,
+				}
+			)
+		)
+	set_submenu_items(items)
 
 
 ## Set submenu items (called by battle_ui).

--- a/game/scripts/ui/battle_command_menu.gd
+++ b/game/scripts/ui/battle_command_menu.gd
@@ -28,9 +28,11 @@ var _target_count: int = 0
 var _character_data: Dictionary = {}
 var _current_mp: int = 0
 
-@onready var _command_list: VBoxContainer = $CommandList
-@onready var _submenu: PanelContainer = $SubMenu
-@onready var _submenu_list: VBoxContainer = $SubMenu/SubMenuList
+# get_node_or_null (not $) so unit tests can instantiate the menu via .new()
+# without a scene tree; every use of these refs is already null-guarded.
+@onready var _command_list: VBoxContainer = get_node_or_null("CommandList")
+@onready var _submenu: PanelContainer = get_node_or_null("SubMenu")
+@onready var _submenu_list: VBoxContainer = get_node_or_null("SubMenu/SubMenuList")
 
 
 func _ready() -> void:

--- a/game/scripts/ui/battle_ui.gd
+++ b/game/scripts/ui/battle_ui.gd
@@ -99,7 +99,10 @@ func _on_turn_ready(
 		_party_panel.set_active_slot(slot)
 	if _command_menu != null:
 		_command_menu.set_enemy_count(enemy_count)
-		_command_menu.show_commands(character_data, is_boss)
+		var current_mp: int = 0
+		if _battle_state != null:
+			current_mp = int(_battle_state.get_member(slot).get("current_mp", 0))
+		_command_menu.show_commands(character_data, is_boss, current_mp)
 
 
 func _on_command_selected(command: Dictionary) -> void:

--- a/game/tests/test_atb_system.gd
+++ b/game/tests/test_atb_system.gd
@@ -1,11 +1,13 @@
 extends GutTest
 ## Tests for ATB gauge system.
 
+const ATBScript := preload("res://scripts/combat/atb_system.gd")
+
 var _atb: Node
 
 
 func before_each() -> void:
-	_atb = preload("res://scripts/combat/atb_system.gd").new()
+	_atb = ATBScript.new()
 	add_child_autofree(_atb)
 
 
@@ -210,3 +212,25 @@ func test_should_pause_timers_wait_submenu() -> void:
 	_atb.set_atb_mode("wait")
 	_atb.set_submenu_open(true)
 	assert_true(_atb.should_pause_timers(), "wait pauses on submenu")
+
+
+# --- Config -> ATB settings mapping (GAP-007) ---
+
+
+func test_settings_from_config_defaults() -> void:
+	var s: Dictionary = ATBScript.settings_from_config({})
+	assert_eq(s.get("mode"), "active", "defaults to active mode")
+	assert_eq(s.get("speed"), 3, "defaults to speed 3")
+
+
+func test_settings_from_config_reads_player_values() -> void:
+	var s: Dictionary = ATBScript.settings_from_config({"atb_mode": "wait", "battle_speed": 5})
+	assert_eq(s.get("mode"), "wait", "uses player's ATB mode")
+	assert_eq(s.get("speed"), 5, "uses player's battle speed")
+
+
+func test_settings_from_config_patience_mode_overrides() -> void:
+	var s: Dictionary = ATBScript.settings_from_config(
+		{"atb_mode": "active", "patience_mode": true}
+	)
+	assert_eq(s.get("mode"), "patience", "patience mode overrides the ATB mode")

--- a/game/tests/test_battle_command_menu.gd
+++ b/game/tests/test_battle_command_menu.gd
@@ -1,0 +1,70 @@
+extends GutTest
+## Tests for battle command-menu submenu population (GAP-001: Magic submenu).
+
+const CommandMenu := preload("res://scripts/ui/battle_command_menu.gd")
+const SpellHelpers := preload("res://scripts/ui/spell_helpers.gd")
+
+const CASTER_ID := "sable"
+const CASTER_LEVEL := 5
+
+
+func _make_menu() -> Node:
+	var m: Node = CommandMenu.new()
+	add_child_autofree(m)
+	return m
+
+
+func _open_magic_submenu(m: Node) -> void:
+	# Magic is index 1 in the command list (Attack, Magic, Ability, Item, Defend, Flee).
+	m._cursor = 1
+	m._confirm_command()
+
+
+func test_magic_submenu_is_populated_from_known_spells() -> void:
+	var known: Array = SpellHelpers.get_known_spells(CASTER_ID, CASTER_LEVEL)
+	assert_gt(known.size(), 0, "precondition: caster knows at least one spell")
+	var m: Node = _make_menu()
+	m.show_commands({"character_id": CASTER_ID, "level": CASTER_LEVEL}, false, 99)
+	_open_magic_submenu(m)
+	assert_eq(m._submenu_items.size(), known.size(), "submenu lists every known spell")
+
+
+func test_magic_submenu_items_carry_a_magic_command_with_spell() -> void:
+	var m: Node = _make_menu()
+	m.show_commands({"character_id": CASTER_ID, "level": CASTER_LEVEL}, false, 99)
+	_open_magic_submenu(m)
+	assert_gt(m._submenu_items.size(), 0, "submenu has items")
+	var item: Dictionary = m._submenu_items[0]
+	var command: Dictionary = item.get("command", {})
+	assert_eq(command.get("type", ""), "magic", "item routes a magic command")
+	assert_true(command.has("spell"), "magic command carries the full spell dict")
+	assert_true(item.has("target_type"), "item declares a target_type for targeting")
+
+
+func test_unaffordable_spells_are_disabled_at_zero_mp() -> void:
+	var m: Node = _make_menu()
+	m.show_commands({"character_id": CASTER_ID, "level": CASTER_LEVEL}, false, 0)
+	_open_magic_submenu(m)
+	var checked_any: bool = false
+	for item: Dictionary in m._submenu_items:
+		var cost: int = int(item.get("command", {}).get("spell", {}).get("mp_cost", 0))
+		if cost > 0:
+			checked_any = true
+			assert_false(item.get("enabled", true), "spell costing %d MP disabled at 0 MP" % cost)
+	assert_true(checked_any, "precondition: at least one spell has an MP cost")
+
+
+func test_id_key_is_accepted_as_a_fallback() -> void:
+	# Raw character JSON uses "id"; the menu should still populate from it.
+	var m: Node = _make_menu()
+	m.show_commands({"id": CASTER_ID, "level": CASTER_LEVEL}, false, 99)
+	_open_magic_submenu(m)
+	assert_gt(m._submenu_items.size(), 0, "id-keyed data still populates the submenu")
+
+
+func test_empty_submenu_for_caster_with_no_spells() -> void:
+	# A non-caster id yields no known spells; submenu stays empty (only cancel works).
+	var m: Node = _make_menu()
+	m.show_commands({"id": "nobody_xyz", "level": 1}, false, 99)
+	_open_magic_submenu(m)
+	assert_eq(m._submenu_items.size(), 0, "no spells -> empty submenu")


### PR DESCRIPTION
## Summary

Bundle 1 — the combat UI/config layer from the gap analysis.

- **GAP-001 (BLOCKER):** battle Magic submenu now populates from the caster's known spells and routes a real `{"type":"magic","spell":...}` command into combat; unaffordable spells are greyed by current MP. New `game/tests/test_battle_command_menu.gd`.
- **GAP-007 (HIGH):** ATB Mode / Battle Speed / Patience Mode config now reaches combat via `ATBSystem.settings_from_config()`; covered in `test_atb_system.gd`.
- **fix(GAP-001):** menu child node refs switched from `$` to `get_node_or_null` so the menu is unit-testable via `.new()` without emitting spurious "node not found" engine errors (battle.tscn unaffected).

## Type

- [x] feat — New functionality
- [x] fix — Bug fix

## Test Plan

- [x] Full GUT suite passes via pre-push hook (924 passing, 0 failing, 54 scripts)
- [x] gdlint + gdformat clean (pre-commit)
- [x] Godot 4.7 `--headless --import` clean

## Notes

This branch was blocked by a local macOS Godot import wedge (uninterruptible U-state) that prevented the pre-push GUT suite from ever running. A reboot cleared the wedge, which then surfaced 5 real test failures in the new GAP-001 file (masked node-ref errors) — fixed here before push. Next: Bundle 2 (combat-resolution layer: GAP-003 status effects, GAP-008 type traits, GAP-010 Cael spike, GAP-002 character commands).
