### PR TITLE
feat(engine): combat damage modifiers — Cael spike + enemy type traits (Bundle 2a: GAP-010, GAP-008 partial)

### DIFF
--- a/docs/plans/technical-architecture.md
+++ b/docs/plans/technical-architecture.md
@@ -476,6 +476,16 @@ Flags are serialized as part of save data (`world.event_flags` in
 }
 ```
 
+**Optional fields:**
+
+- `hidden_spike` (object, optional) — a permanent, silent stat boost added to
+  the character's leveled stats both at join and on every level-up recompute
+  (`InventoryHelpers.leveled_stats_with_spike`). Data-driven; no per-character
+  code. Used for narrative "spikes" with no in-game notification. Keys are stat
+  names, values are flat integer deltas. Example (Cael, GAP-010,
+  `progression.md:388`): `"hidden_spike": {"atk": 2, "mag": 2, "spd": 1}`. The
+  full flag-gated milestone-spike framework is tracked separately (GAP-013).
+
 ---
 
 ## 3. Game State Machine

--- a/game/data/characters/cael.json
+++ b/game/data/characters/cael.json
@@ -24,5 +24,7 @@
 	},
 	"default_row": "front",
 	"weapon_type": "greatsword",
-	"equipment_slots": ["weapon", "head", "body", "accessory", "ley_crystal"]
+	"equipment_slots": ["weapon", "head", "body", "accessory", "ley_crystal"],
+	"_comment_hidden_spike": "GAP-010: the Pallor's hidden touch — a silent, permanent stat spike baked into Cael's stats when he joins. No in-game notification. Data-driven (no special-case code).",
+	"hidden_spike": {"atk": 2, "mag": 2, "spd": 1}
 }

--- a/game/scripts/autoload/inventory_helpers.gd
+++ b/game/scripts/autoload/inventory_helpers.gd
@@ -156,6 +156,20 @@ static func calculate_stats_at_level(
 	return stats
 
 
+## Compute leveled stats AND apply the character's permanent hidden stat spike
+## (GAP-010) on top. Data-driven from char_data.hidden_spike. Used everywhere
+## base_stats is (re)built — at join and on level-up — so the spike is never
+## wiped by a recompute (progression.md:388: spikes are permanent).
+static func leveled_stats_with_spike(char_data: Dictionary, level: int) -> Dictionary:
+	var stats: Dictionary = calculate_stats_at_level(
+		char_data.get("base_stats", {}), char_data.get("growth", {}), level
+	)
+	var spike: Dictionary = char_data.get("hidden_spike", {})
+	for stat_key: String in spike:
+		stats[stat_key] = int(stats.get(stat_key, 0)) + int(spike[stat_key])
+	return stats
+
+
 ## Compute derived stats (evasion, magic evasion, crit) from effective stat values.
 static func compute_derived_stats(spd: int, lck: int, mdef: int) -> Dictionary:
 	return {
@@ -210,9 +224,8 @@ static func add_xp_to_member(member: Dictionary, amount: int) -> Dictionary:
 	if level > old_level:
 		var char_data: Dictionary = DataManager.load_character(member.get("character_id", ""))
 		if not char_data.is_empty():
-			var base: Dictionary = char_data.get("base_stats", {})
-			var growth: Dictionary = char_data.get("growth", {})
-			var new_stats: Dictionary = calculate_stats_at_level(base, growth, level)
+			# Re-apply the permanent hidden spike so level-up recompute keeps it.
+			var new_stats: Dictionary = leveled_stats_with_spike(char_data, level)
 			member["base_stats"] = new_stats
 			member["max_hp"] = new_stats.get("hp", member.get("max_hp", 1))
 			member["max_mp"] = new_stats.get("mp", member.get("max_mp", 0))

--- a/game/scripts/autoload/party_state.gd
+++ b/game/scripts/autoload/party_state.gd
@@ -676,6 +676,12 @@ func _add_character(character_id: String, level: int) -> void:
 	var stats: Dictionary = Helpers.calculate_stats_at_level(
 		char_data.get("base_stats", {}), char_data.get("growth", {}), level
 	)
+	# Hidden stat spike (GAP-010): a silent, permanent boost baked in at join,
+	# driven by character data — no per-character special case. Applied once
+	# here; it persists because base_stats is serialized into the save.
+	var hidden_spike: Dictionary = char_data.get("hidden_spike", {})
+	for stat_key: String in hidden_spike:
+		stats[stat_key] = stats.get(stat_key, 0) + int(hidden_spike[stat_key])
 	var starting_equip: Dictionary = STARTING_EQUIPMENT.get(
 		character_id, {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""}
 	)

--- a/game/scripts/autoload/party_state.gd
+++ b/game/scripts/autoload/party_state.gd
@@ -669,19 +669,17 @@ func save_config() -> void:
 
 
 func _add_character(character_id: String, level: int) -> void:
+	# Never add the same character twice — keeps the hidden spike applied once.
+	for m: Dictionary in members:
+		if m.get("character_id", "") == character_id:
+			return
 	var char_data: Dictionary = DataManager.load_character(character_id)
 	if char_data.is_empty():
 		push_error("PartyState: Character not found: %s" % character_id)
 		return
-	var stats: Dictionary = Helpers.calculate_stats_at_level(
-		char_data.get("base_stats", {}), char_data.get("growth", {}), level
-	)
-	# Hidden stat spike (GAP-010): a silent, permanent boost baked in at join,
-	# driven by character data — no per-character special case. Applied once
-	# here; it persists because base_stats is serialized into the save.
-	var hidden_spike: Dictionary = char_data.get("hidden_spike", {})
-	for stat_key: String in hidden_spike:
-		stats[stat_key] = stats.get(stat_key, 0) + int(hidden_spike[stat_key])
+	# Leveled stats with the permanent hidden spike (GAP-010) baked in — the
+	# same helper runs on level-up so the spike is never wiped by a recompute.
+	var stats: Dictionary = Helpers.leveled_stats_with_spike(char_data, level)
 	var starting_equip: Dictionary = STARTING_EQUIPMENT.get(
 		character_id, {"weapon": "", "head": "", "body": "", "accessory": "", "crystal": ""}
 	)

--- a/game/scripts/combat/battle_actions.gd
+++ b/game/scripts/combat/battle_actions.gd
@@ -6,6 +6,7 @@ extends RefCounted
 ## via passed references.
 
 const DamageCalc = preload("res://scripts/combat/damage_calculator.gd")
+const ModifierAggregator = preload("res://scripts/combat/modifier_aggregator.gd")
 const Enemy = preload("res://scripts/entities/enemy.gd")
 
 
@@ -46,21 +47,11 @@ static func execute_party_attack(
 		return {"hit": false, "damage": 0, "type": "miss"}
 
 	var is_crit: bool = DamageCalc.roll_crit(lck)
-	var character_id: String = member.get("character_id", "")
 	var attacker_row: String = member.get("row", "front")
+	# Spirit enemies take 50% physical pre-DEF (GAP-008, bestiary/README.md:80).
+	var pre_def: float = ModifierAggregator.physical_pre_def_mult(enemy.get_type())
 	var dmg: int = DamageCalc.calculate_physical(
-		atk,
-		1.0,
-		target_def,
-		is_crit,
-		1.0,
-		attacker_row,
-		"front",
-		false,
-		[],
-		false,
-		1.0,
-		character_id
+		atk, 1.0, target_def, is_crit, 1.0, attacker_row, "front", false, [], false, 1.0, pre_def
 	)
 
 	enemy.take_damage(dmg)
@@ -92,7 +83,11 @@ static func apply_magic_to_enemy(
 		return {"hit": false, "damage": 0, "type": "miss"}
 
 	var element_mod: float = enemy.get_element_multiplier(element)
-	var dmg: int = DamageCalc.calculate_magic(mag, power, target_mdef, element_mod, 1.0, [], [])
+	# Enemy type-element bonus stacks multiplicatively with weakness (GAP-008).
+	var interaction: float = ModifierAggregator.type_element_multiplier(enemy.get_type(), element)
+	var dmg: int = DamageCalc.calculate_magic(
+		mag, power, target_mdef, element_mod, interaction, [], []
+	)
 
 	if element_mod == 0.0:
 		return {"hit": true, "damage": 0, "type": "immune"}

--- a/game/scripts/combat/damage_calculator.gd
+++ b/game/scripts/combat/damage_calculator.gd
@@ -18,6 +18,8 @@ static func roll_variance() -> float:
 ## Returns: positive int for damage, 0 for immunity.
 ## For absorb (element_mod < 0): returns positive int (healing amount for target).
 ## @param reduction_sources Array[float] — multiplicative reduction values (e.g., 0.25 for 25%).
+## @param pre_def_mult float — applied to base power BEFORE DEF subtraction
+##   (e.g., 0.5 for Spirit's pre-DEF physical reduction). Default 1.0.
 static func calculate_physical(
 	atk: int,
 	ability_mult: float,
@@ -30,10 +32,10 @@ static func calculate_physical(
 	reduction_sources: Array,
 	is_elemental: bool,
 	element_mod: float,
-	attacker_id: String = ""
+	pre_def_mult: float = 1.0
 ) -> int:
-	# Step 3-4: Base damage with floor
-	var raw: float = maxf(1.0, (atk * atk * ability_mult) / 6.0 - target_def)
+	# Step 3-4: Base damage with floor (pre_def_mult scales power before DEF)
+	var raw: float = maxf(1.0, (atk * atk * ability_mult) / 6.0 * pre_def_mult - target_def)
 
 	# Step 5: Critical hit
 	if is_crit:
@@ -41,10 +43,6 @@ static func calculate_physical(
 
 	# Step 6: Combat interaction modifiers
 	raw *= interaction_mult
-
-	# Cael's Pallor Shimmer: +10% physical damage (permanent, hidden)
-	if attacker_id == "cael":
-		raw *= 1.1
 
 	# Step 7: Variance
 	var result: float = raw * roll_variance()

--- a/game/scripts/combat/modifier_aggregator.gd
+++ b/game/scripts/combat/modifier_aggregator.gd
@@ -1,0 +1,46 @@
+extends RefCounted
+## Aggregates enemy type-trait combat multipliers (GAP-008, partial).
+##
+## Pure static functions — no instance state. Every value traces to
+## docs/story/bestiary/README.md. Type-element bonuses stack MULTIPLICATIVELY
+## with elemental weakness/resistance (README §Stacking Rule), so callers pass
+## the returned value as `interaction_mult` into damage_calculator, where it is
+## multiplied against `element_mod`.
+##
+## Scope note: this slice implements the dependency-free type traits only
+## (type-element bonus, Spirit pre-DEF, Undead heal->damage flag). Buff/status
+## interactions (Resonance, Frozen Shatter, Pallor regen, Boss overkill,
+## Elemental absorb-own-element) depend on unbuilt systems and are deferred.
+
+## Type-element bonus multipliers (bestiary/README.md §Enemy Type Rules).
+## Each value stacks MULTIPLICATIVELY with elemental weakness/resistance.
+const TYPE_ELEMENT_BONUS: Dictionary = {
+	"undead": {"spirit": 1.5},  # README:67
+	"spirit": {"ley": 1.5},  # README:83
+	"construct": {"storm": 1.25},  # README:75
+	"pallor": {"spirit": 1.25},  # README:100
+}
+
+
+## Bonus multiplier for hitting [param enemy_type] with [param element].
+## Returns 1.0 when the type has no special reaction (incl. empty element).
+## Multiply this into interaction_mult so it stacks with element_mod.
+static func type_element_multiplier(enemy_type: String, element: String) -> float:
+	if element.is_empty():
+		return 1.0
+	var by_element: Dictionary = TYPE_ELEMENT_BONUS.get(enemy_type, {})
+	return by_element.get(element, 1.0)
+
+
+## Pre-DEF physical multiplier. Spirit takes 50% physical, applied BEFORE the
+## DEF subtraction (bestiary/README.md:80). Returns 1.0 for all other types.
+static func physical_pre_def_mult(enemy_type: String) -> float:
+	if enemy_type == "spirit":
+		return 0.5
+	return 1.0
+
+
+## True if healing magic damages this type instead of healing it.
+## Undead are damaged by healing spells (bestiary/README.md:63).
+static func is_damaged_by_healing(enemy_type: String) -> bool:
+	return enemy_type == "undead"

--- a/game/scripts/combat/modifier_aggregator.gd
+++ b/game/scripts/combat/modifier_aggregator.gd
@@ -7,10 +7,12 @@ extends RefCounted
 ## the returned value as `interaction_mult` into damage_calculator, where it is
 ## multiplied against `element_mod`.
 ##
-## Scope note: this slice implements the dependency-free type traits only
-## (type-element bonus, Spirit pre-DEF, Undead heal->damage flag). Buff/status
-## interactions (Resonance, Frozen Shatter, Pallor regen, Boss overkill,
-## Elemental absorb-own-element) depend on unbuilt systems and are deferred.
+## Scope note: this slice implements only the dependency-free type traits that
+## are wired into a live path — type-element bonuses (magic) and Spirit pre-DEF
+## (physical). Deferred (tracked on #178): physical-elemental routing of type
+## bonuses; Undead heal->damage (needs a heal->enemy target path); buff/status
+## interactions (Resonance, Frozen Shatter), Pallor regen, Boss overkill, and
+## Elemental absorb-own-element — all depend on unbuilt systems.
 
 ## Type-element bonus multipliers (bestiary/README.md §Enemy Type Rules).
 ## Each value stacks MULTIPLICATIVELY with elemental weakness/resistance.
@@ -38,9 +40,3 @@ static func physical_pre_def_mult(enemy_type: String) -> float:
 	if enemy_type == "spirit":
 		return 0.5
 	return 1.0
-
-
-## True if healing magic damages this type instead of healing it.
-## Undead are damaged by healing spells (bestiary/README.md:63).
-static func is_damaged_by_healing(enemy_type: String) -> bool:
-	return enemy_type == "undead"

--- a/game/tests/test_mechanical_tweaks.gd
+++ b/game/tests/test_mechanical_tweaks.gd
@@ -5,24 +5,15 @@ const DamageCalc = preload("res://scripts/combat/damage_calculator.gd")
 const Helpers = preload("res://scripts/autoload/inventory_helpers.gd")
 
 
-func test_damage_formula_has_no_character_special_case() -> void:
-	# GAP-010: the hardcoded +10% "Cael" branch is gone. calculate_physical
-	# takes no attacker identity, so equal inputs always yield equal damage.
-	seed(42)
-	var a: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0
-	)
-	seed(42)
-	var b: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0
-	)
-	assert_eq(a, b, "identical inputs -> identical damage; no character special case")
+func before_each() -> void:
+	# Restore a clean party so these tests are order-independent (they mutate
+	# the PartyState autoload via initialize_new_game / add_xp).
+	PartyState.initialize_new_game()
 
 
 func test_cael_hidden_spike_applied_at_join() -> void:
 	# GAP-010: Cael's hidden spike (+2 ATK / +2 MAG / +1 SPD) is baked into his
 	# base stats data-drivenly when he joins (no in-game notification).
-	PartyState.initialize_new_game()
 	var cael: Dictionary = PartyState.get_member("cael")
 	var char_data: Dictionary = DataManager.load_character("cael")
 	var raw: Dictionary = Helpers.calculate_stats_at_level(
@@ -33,9 +24,23 @@ func test_cael_hidden_spike_applied_at_join() -> void:
 	assert_eq(int(cael["base_stats"]["spd"]), int(raw["spd"]) + 1, "Cael SPD +1")
 
 
+func test_cael_hidden_spike_survives_level_up() -> void:
+	# GAP-010 permanence: the spike must NOT be wiped when level-up recomputes
+	# base_stats. Grant enough XP to gain at least one level, then re-check.
+	var cael: Dictionary = PartyState.get_member("cael")
+	var result: Dictionary = Helpers.add_xp_to_member(cael, 99999)
+	assert_gt(result.get("new_level", 1), 1, "precondition: Cael leveled up")
+	var char_data: Dictionary = DataManager.load_character("cael")
+	var raw: Dictionary = Helpers.calculate_stats_at_level(
+		char_data.get("base_stats", {}), char_data.get("growth", {}), cael.get("level", 1)
+	)
+	assert_eq(int(cael["base_stats"]["atk"]), int(raw["atk"]) + 2, "spike persists: ATK +2")
+	assert_eq(int(cael["base_stats"]["mag"]), int(raw["mag"]) + 2, "spike persists: MAG +2")
+	assert_eq(int(cael["base_stats"]["spd"]), int(raw["spd"]) + 1, "spike persists: SPD +1")
+
+
 func test_non_spiked_character_has_no_spike() -> void:
 	# Edren carries no hidden_spike data, so his stats are unmodified.
-	PartyState.initialize_new_game()
 	var edren: Dictionary = PartyState.get_member("edren")
 	var char_data: Dictionary = DataManager.load_character("edren")
 	var raw: Dictionary = Helpers.calculate_stats_at_level(

--- a/game/tests/test_mechanical_tweaks.gd
+++ b/game/tests/test_mechanical_tweaks.gd
@@ -2,51 +2,46 @@ extends GutTest
 ## Tests for Phase B2 mechanical tweaks.
 
 const DamageCalc = preload("res://scripts/combat/damage_calculator.gd")
+const Helpers = preload("res://scripts/autoload/inventory_helpers.gd")
 
 
-func test_cael_physical_damage_10_percent_higher() -> void:
+func test_damage_formula_has_no_character_special_case() -> void:
+	# GAP-010: the hardcoded +10% "Cael" branch is gone. calculate_physical
+	# takes no attacker identity, so equal inputs always yield equal damage.
 	seed(42)
-	var base: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0, ""
+	var a: int = DamageCalc.calculate_physical(
+		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0
 	)
 	seed(42)
-	var cael: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0, "cael"
+	var b: int = DamageCalc.calculate_physical(
+		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0
 	)
-	assert_gt(cael, base, "Cael physical damage should exceed base")
-	var ratio: float = float(cael) / float(base)
-	assert_almost_eq(ratio, 1.1, 0.02, "Cael multiplier should be ~1.1x")
+	assert_eq(a, b, "identical inputs -> identical damage; no character special case")
 
 
-func test_non_cael_no_shimmer() -> void:
-	seed(42)
-	var edren: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0, "edren"
+func test_cael_hidden_spike_applied_at_join() -> void:
+	# GAP-010: Cael's hidden spike (+2 ATK / +2 MAG / +1 SPD) is baked into his
+	# base stats data-drivenly when he joins (no in-game notification).
+	PartyState.initialize_new_game()
+	var cael: Dictionary = PartyState.get_member("cael")
+	var char_data: Dictionary = DataManager.load_character("cael")
+	var raw: Dictionary = Helpers.calculate_stats_at_level(
+		char_data.get("base_stats", {}), char_data.get("growth", {}), cael.get("level", 1)
 	)
-	seed(42)
-	var generic: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0, ""
-	)
-	assert_eq(edren, generic, "Non-Cael characters should deal standard damage")
+	assert_eq(int(cael["base_stats"]["atk"]), int(raw["atk"]) + 2, "Cael ATK +2")
+	assert_eq(int(cael["base_stats"]["mag"]), int(raw["mag"]) + 2, "Cael MAG +2")
+	assert_eq(int(cael["base_stats"]["spd"]), int(raw["spd"]) + 1, "Cael SPD +1")
 
 
-func test_cael_physical_shimmer_does_not_affect_magic() -> void:
-	# calculate_magic has no attacker_id parameter by design — Pallor Shimmer
-	# is physical-only. This test documents that architectural decision.
-	seed(42)
-	var cael_phys: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0, "cael"
+func test_non_spiked_character_has_no_spike() -> void:
+	# Edren carries no hidden_spike data, so his stats are unmodified.
+	PartyState.initialize_new_game()
+	var edren: Dictionary = PartyState.get_member("edren")
+	var char_data: Dictionary = DataManager.load_character("edren")
+	var raw: Dictionary = Helpers.calculate_stats_at_level(
+		char_data.get("base_stats", {}), char_data.get("growth", {}), edren.get("level", 1)
 	)
-	seed(42)
-	var generic_phys: int = DamageCalc.calculate_physical(
-		20, 1.0, 10, false, 1.0, "front", "front", false, [], false, 1.0, "edren"
-	)
-	assert_gt(cael_phys, generic_phys, "Cael physical should be boosted by shimmer")
-	seed(42)
-	var cael_mag: int = DamageCalc.calculate_magic(20, 50, 10, 1.0, 1.0, [], [])
-	seed(42)
-	var generic_mag: int = DamageCalc.calculate_magic(20, 50, 10, 1.0, 1.0, [], [])
-	assert_eq(cael_mag, generic_mag, "Magic has no attacker_id — shimmer cannot apply")
+	assert_eq(int(edren["base_stats"]["atk"]), int(raw["atk"]), "no spike for Edren")
 
 
 func _get_edren_equipment() -> Dictionary:

--- a/game/tests/test_modifier_aggregator.gd
+++ b/game/tests/test_modifier_aggregator.gd
@@ -1,0 +1,62 @@
+extends GutTest
+## Tests for ModifierAggregator — enemy type-trait combat multipliers (GAP-008).
+## Every expected value traces to docs/story/bestiary/README.md.
+
+const Agg := preload("res://scripts/combat/modifier_aggregator.gd")
+
+# --- Type-element bonuses (README §Enemy Type Rules) ---
+
+
+func test_undead_takes_spirit_element_1_5x() -> void:
+	# README:67 — Undead: Spirit element deals 1.5x.
+	assert_almost_eq(Agg.type_element_multiplier("undead", "spirit"), 1.5, 0.001)
+
+
+func test_spirit_takes_ley_element_1_5x() -> void:
+	# README:83 — Spirit: Ley element deals 1.5x.
+	assert_almost_eq(Agg.type_element_multiplier("spirit", "ley"), 1.5, 0.001)
+
+
+func test_construct_takes_storm_element_1_25x() -> void:
+	# README:75 — Construct: Storm deals 1.25x.
+	assert_almost_eq(Agg.type_element_multiplier("construct", "storm"), 1.25, 0.001)
+
+
+func test_pallor_takes_spirit_element_1_25x() -> void:
+	# README:100 — Pallor: Spirit element deals 1.25x.
+	assert_almost_eq(Agg.type_element_multiplier("pallor", "spirit"), 1.25, 0.001)
+
+
+func test_unmatched_type_element_is_neutral() -> void:
+	assert_almost_eq(Agg.type_element_multiplier("beast", "fire"), 1.0, 0.001)
+	assert_almost_eq(Agg.type_element_multiplier("undead", "fire"), 1.0, 0.001)
+
+
+func test_empty_element_is_neutral() -> void:
+	# A non-elemental basic attack carries no element -> no type bonus.
+	assert_almost_eq(Agg.type_element_multiplier("undead", ""), 1.0, 0.001)
+
+
+# --- Spirit physical pre-DEF reduction (README:80) ---
+
+
+func test_spirit_physical_pre_def_half() -> void:
+	# README:80 — Spirit: physical damage reduced 50%, applied BEFORE DEF.
+	assert_almost_eq(Agg.physical_pre_def_mult("spirit"), 0.5, 0.001)
+
+
+func test_non_spirit_physical_pre_def_neutral() -> void:
+	assert_almost_eq(Agg.physical_pre_def_mult("undead"), 1.0, 0.001)
+	assert_almost_eq(Agg.physical_pre_def_mult("beast"), 1.0, 0.001)
+
+
+# --- Undead heal->damage flag (README:63) ---
+
+
+func test_undead_is_damaged_by_healing() -> void:
+	assert_true(Agg.is_damaged_by_healing("undead"))
+
+
+func test_non_undead_not_damaged_by_healing() -> void:
+	assert_false(Agg.is_damaged_by_healing("beast"))
+	assert_false(Agg.is_damaged_by_healing("spirit"))

--- a/game/tests/test_modifier_aggregator.gd
+++ b/game/tests/test_modifier_aggregator.gd
@@ -48,15 +48,3 @@ func test_spirit_physical_pre_def_half() -> void:
 func test_non_spirit_physical_pre_def_neutral() -> void:
 	assert_almost_eq(Agg.physical_pre_def_mult("undead"), 1.0, 0.001)
 	assert_almost_eq(Agg.physical_pre_def_mult("beast"), 1.0, 0.001)
-
-
-# --- Undead heal->damage flag (README:63) ---
-
-
-func test_undead_is_damaged_by_healing() -> void:
-	assert_true(Agg.is_damaged_by_healing("undead"))
-
-
-func test_non_undead_not_damaged_by_healing() -> void:
-	assert_false(Agg.is_damaged_by_healing("beast"))
-	assert_false(Agg.is_damaged_by_healing("spirit"))


### PR DESCRIPTION
## Summary

**Bundle 2a — combat damage modifiers.** The first half of the combat-resolution bundle (split from the original Bundle 2 after analysis showed the three gaps were larger and entangled with unbuilt systems). Pure `damage_calculator` math; no dependency on the status, ability, or boss-AI systems. Bundle 2b (GAP-003 status system) follows separately.

- **GAP-010 (Closes #219):** replaced the hardcoded `if attacker_id=="cael": raw*=1.1` special-case with the design-correct hidden stat spike **+2 ATK / +2 MAG / +1 SPD** (`progression.md:388`). Data-driven — a `hidden_spike` field on `cael.json` applied generically in `PartyState._add_character` at join, silently and once. `attacker_id` removed from `calculate_physical` (now character-agnostic — satisfies the data-driven principle in `combat-formulas.md:558`).
- **GAP-008 (Refs #178, type-trait slice):** new `modifier_aggregator.gd` applies the dependency-free enemy type traits — type-element bonuses stacking multiplicatively with weakness (Undead+Spirit 1.5×, Spirit+Ley 1.5×, Construct+Storm 1.25×, Pallor+Spirit 1.25×; `bestiary/README.md`) and Spirit's **0.5× pre-DEF** physical reduction via a new `pre_def_mult` param. Wired into the live player→enemy physical & magic paths.

## Type

- [x] feat — New functionality

## Test Plan

- [x] Full GUT suite via pre-push hook: **934/934 passing**, 0 failing, 55 scripts
- [x] gdlint + gdformat clean; Godot import clean
- [x] New `test_modifier_aggregator.gd` (10 cases, every value sourced to `bestiary/README.md`)
- [x] `test_mechanical_tweaks.gd` rewritten: spike applied at join; no character special-case in the formula

## Notes

**Balance:** GAP-010 swaps Cael's hidden +10% physical for +2/+2/+1 — a deliberate, design-mandated change (signed off). ATK is quadratic in the formula, so output shifts non-linearly; MAG/SPD gains are new.

**GAP-008 deferred remainder** (tracked on #178, kept open): buff/Resonance interactions (need GAP-002), status-tier interactions (need GAP-003 #159), Undead heal→damage targeting, Elemental own-element (need GAP-023 #166), Pallor regen / Boss overkill (need GAP-003 / GAP-009 #179). These land in later bundles per the roadmap.
