### PR TITLE
feat(engine): enemy special abilities + Ironmouth bestiary (GAP-024/028)

### DIFF
--- a/docs/story/bestiary/CONTINUATION.md
+++ b/docs/story/bestiary/CONTINUATION.md
@@ -179,7 +179,7 @@ Death, Petrify, Stop, Sleep, Confusion (can be overridden per boss).
 | File | Purpose |
 |------|---------|
 | `docs/story/bestiary/README.md` | Canonical rules, formulas, types |
-| `docs/story/bestiary/act-i.md` | Completed Act I (25 enemies) |
+| `docs/story/bestiary/act-i.md` | Completed Act I (27 enemies) |
 | `docs/story/bestiary/palette-families.md` | 32 families with tier projections |
 | `docs/story/dungeons-world.md` | World dungeon layouts, boss descriptions, enemy names |
 | `docs/story/dungeons-city.md` | City dungeon layouts, enemy names |

--- a/docs/story/bestiary/README.md
+++ b/docs/story/bestiary/README.md
@@ -8,7 +8,7 @@
 
 | File | Contents |
 |------|----------|
-| [act-i.md](act-i.md) | Ember Vein, Fenmother's Hollow, Overworld Act I (25 enemies) |
+| [act-i.md](act-i.md) | Ember Vein, Fenmother's Hollow, Overworld Act I, Ironmouth Docks (27 enemies) |
 | [act-ii.md](act-ii.md) | Valdris Siege, Ley Line Depths, Ashmark, Bellhaven, Overworld Act II (33 enemies) |
 | [interlude.md](interlude.md) | Rail Tunnels, Corrund, Catacombs, Caldera, Axis Tower, Ironmark (52 enemies) |
 | [act-iii.md](act-iii.md) | Pallor Wastes, Convergence, Ley F5, Dry Well F5–7, Forgotten Forge, Ley Scar, Overworld (69 enemies) |

--- a/docs/story/bestiary/act-i.md
+++ b/docs/story/bestiary/act-i.md
@@ -1,11 +1,12 @@
 # Act I Bestiary
 
 Enemies encountered during Act I: Ember Vein, Fenmother's Hollow,
-and the Overworld between Valdris and the Hollow. See
+the Overworld between Valdris and the Hollow, and the Ironmouth outpost
+(the Act I opening / Scene 3 escape on the Carradan border). See
 [README.md](README.md) for type rules, stat formulas, and reward
 calculations.
 
-**Total:** 25 enemies (20 regular + 1 unique + 2 mini-bosses + 2 bosses)
+**Total:** 27 enemies (22 regular + 1 unique + 2 mini-bosses + 2 bosses)
 
 ---
 
@@ -88,18 +89,44 @@ generally less dangerous than dungeon enemies at the same level.
 
 ---
 
+## Ironmouth Docks (Act I — Scene 3 Escape)
+
+> **Zone note:** Ironmouth is the story's opening setting — a Carradan
+> Compact mining outpost on the southern border of the Thornmere Wilds
+> ([locations.md](../locations.md): "This is where the story begins").
+> The party's first destination; a Carradan ambush forces the escape that
+> drives them into the Wilds. These two enemies are the Compact soldiers of
+> that ambush (the forced Scene 3 encounter is 2× Compact Patrol + 1× Compact
+> Scout, flee-disabled, with Lira and Sable joining). They are **early
+> deployments of the Soldier / Compact family** (base: Compact Soldier Lv 18,
+> documented in [act-ii.md](act-ii.md) / [palette-families.md](palette-families.md)),
+> appearing far below their projected level per the README "early deployment"
+> rule. Stats are transcribed as-shipped from `game/data/enemies/act_i.json`;
+> their reward/HP-curve anomalies are tracked as a separate balance follow-up.
+
+Recommended party level: 5–6.
+
+| Name | Type | Lv | HP | MP | ATK | DEF | MAG | MDEF | SPD | Gold | Exp | Steal | Drop | Weak | Resists | Absorbs | Status Immunities | Location(s) |
+|------|------|----|----|----|----|-----|-----|------|-----|------|-----|-------|------|------|---------|---------|-------------------|-------------|
+| Compact Patrol | Humanoid | 5 | 180 | 0 | 16 | 14 | 8 | 10 | 10 | 30 | 18 | — | Potion (75%) | — | — | — | — | Ironmouth Docks |
+| Compact Scout | Humanoid | 6 | 140 | 0 | 14 | 10 | 8 | 8 | 14 | 35 | 20 | — | Antidote (50%) | — | — | — | — | Ironmouth Docks |
+
+---
+
 ## Act I Summary
 
-- **Total:** 25 enemies (20 regular + 1 unique + 2 mini-bosses + 2 bosses)
+- **Total:** 27 enemies (22 regular + 1 unique + 2 mini-bosses + 2 bosses)
 - **Type coverage:** Beast (11), Undead (3), Construct (1), Spirit (3),
-  Elemental (4), Humanoid (1), Boss (2)
-- **Threat spread:** Trivial (4), Low (10), Standard (6), Dangerous (3),
+  Elemental (4), Humanoid (3), Boss (2)
+- **Threat spread:** Trivial (4), Low (12), Standard (6), Dangerous (3),
   Boss (2)
 - **Level range:** 1–12
 - **Families started:** 19 (see [palette-families.md](palette-families.md))
   - Vermin, Mite, Dead, Crystal, Shade, Warden, Wisp, Drake, Serpent,
     Leech, Lurker, Jellyfish, Elemental, Hare, Beetle, Bandit, Sprite,
     Boar, Wolf
+  - Compact Patrol / Compact Scout are early deployments of the Soldier
+    family (base appears Act II), not a new Act I family.
 - **Unique:** The Flickering (1)
 - **Mechanics introduced:** Basic combat, swarm encounters, undead rules
   (heal-to-damage), elemental weaknesses, physical resistance (Spirit type),

--- a/docs/story/bestiary/enemy-ability-conventions.md
+++ b/docs/story/bestiary/enemy-ability-conventions.md
@@ -1,0 +1,137 @@
+# Enemy Ability Conventions
+
+> **Status:** canonical reference (GAP-024). This document fills a deliberate
+> gap in the design corpus: `palette-families.md` assigns every Act I enemy an
+> ability **kit by name** (e.g. *Venom Spit (Poison)*, *Pack Howl (ATK up for
+> all wolves)*, *Shard Burst (AoE on death)*) but is **silent on the numbers** —
+> ability power, status hit-rates, and buff magnitudes/durations. Rather than
+> invent values, every convention below is **derived from an already-documented
+> canon value** (a player spell, a combat formula, a status-table entry) and
+> cites its source to `file:line`. Enemy ability data in `game/data/enemies/`
+> references a rule here for each value it sets.
+
+This document defines (1) the JSON ability schema, and (2) the
+canon-derived defaults that resolve each silent value.
+
+---
+
+## 1. Ability JSON schema
+
+Each enemy entry in `game/data/enemies/<act>.json` MAY carry an `abilities`
+array, slotted alongside `weaknesses` / `resistances` / `status_immunities`.
+Each element is a dictionary:
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `id` | String | — (required) | Stable ability id (snake_case). |
+| `name` | String | `id` | Display name. |
+| `type` | String | `"attack"` | `"attack"` (physical formula), `"magic"` (magic formula), or `"buff"`. |
+| `element` | String | `""` | Damage element; `""` = non-elemental. |
+| `ability_mult` | float | `1.0` | Physical power multiplier (`type:"attack"`). |
+| `spell_power` | int | `0` | Magic spell power (`type:"magic"`). |
+| `target` | String | `"single"` | `"single"`, `"all"` (party-wide AoE), or `"self"`. |
+| `status` | String | `""` | Status inflicted on hit (e.g. `"poison"`). |
+| `status_rate` | int | `0` | Base hit-rate fed to the two-stage roll. |
+| `status_duration` | Variant | `null` | Explicit duration override; `null` = canonical (`StatusEffects.resolve_duration`). |
+| `hits` | int | `1` | Multi-hit count. |
+| `aoe_on_death` | bool | `false` | If true, the ability fires against the party when the bearer dies. |
+| `buff` | Dictionary | `{}` | `{stat, mult, duration, scope}` for `type:"buff"` (see §2.4). |
+
+Every damage/roll value resolves through the existing combat code — there is
+**no** new damage math. `type:"attack"` → `DamageCalc.calculate_physical`
+(`ability_mult` is the power knob); `type:"magic"` →
+`DamageCalc.calculate_magic` (`spell_power` is the power knob); `status` →
+`DamageCalc.roll_status` two-stage accuracy; `buff` → enemy stat multiplier.
+
+---
+
+## 2. Canon-derived defaults for silent values
+
+### 2.1 Damaging physical abilities — `ability_mult: 1.0`
+
+Basic strikes whose power is unspecified (Bite, Claw, Slash, Scratch, Pinch,
+Fang Strike, Heavy Swing, Gore, Pounce, Tail Swipe, Lunge, …) use
+`ability_mult 1.0` — i.e. a normal basic attack through the physical formula
+`(atk² · ability_mult)/6 − def` (combat-formulas.md § Physical Attack
+Resolution). Descriptor words like *Heavy* or *high ATK* (Gore) are **not**
+bumped above 1.0, because no doc supplies a multiplier — the enemy's own ATK
+stat already encodes its role (a Boar's high ATK makes Gore hit hard at
+`ability_mult 1.0`).
+
+### 2.2 Single-target elemental/magic abilities — `spell_power: 14`
+
+Magic-typed single-target enemy abilities (Flicker = Flame, Spark = Ley,
+Shadow Touch = magic) use `spell_power 14`, the documented **Tier 1
+single-target spell power floor** for player attack spells (Cinder
+`magic.md:152`, Frostbite `magic.md:198` — both *Spell power 14*). Tier 1
+matches the Act I regular-enemy band (`palette-families.md` Tier 1 kits).
+
+### 2.3 AoE elemental abilities — `spell_power: 9`
+
+Party-wide elemental abilities (Frost Burst, Shard Burst) use `spell_power 9`.
+`magic.md:101` states *"AoE spell power uses approximately 60–70% of the
+single-target ranges."* Applying 65% to the Tier 1 single-target floor of 14
+(§2.2) gives `round(14 × 0.65) = 9`. There is **no damage splitting** — each
+party member takes the full AoE hit (combat-formulas.md:633).
+
+### 2.4 Stat buffs — reuse the player-analog magnitude & duration
+
+No enemy buff magnitude is documented, so each maps to the player buff spell
+with the same effect (its magnitude and duration are canon):
+
+| Enemy ability | Buffs | Mult | Duration | Player analog (source) |
+|---------------|-------|------|----------|------------------------|
+| Pack Howl | ATK | ×1.30 | 5 turns | Rallying Cry +30% ATK / 5t (`magic.md:834`) |
+| Guard Stance | DEF | ×1.40 | 5 turns | Ironhide +40% DEF / 5t (`magic.md:790`) |
+| Coil | SPD | ×1.50 | 5 turns | Quickstep +50% / 5t (`magic.md:812`) |
+| Elemental Shield | MDEF | ×1.40 | 5 turns | Wardglass +40% MDEF / 5t (`magic.md:801`) |
+
+`scope` is `"self"` (buffs only the caster) or `"pack"` (buffs every living
+enemy sharing the caster's `type`, e.g. Pack Howl across all Beasts/wolves in
+the encounter, per `palette-families.md:435` *"ATK up for all wolves"*).
+
+### 2.5 Offensive status hit-rate — `status_rate: 70`
+
+Enemy status base-rates are unspecified. `magic.md:107` documents the player
+band: *"Status spells have a base hit rate of 60–80%."* Enemy offensive
+statuses use **70** (band midpoint), then run the same two-stage accuracy roll
+as player status spells (`DamageCalc.roll_status`, combat-formulas.md:478–484):
+Stage 1 `effective = base_rate · MAG/(MAG+MDEF)`, Stage 2 magic-evasion
+`(MDEF+SPD)/8` capped at 40%. The status's **effect** (e.g. Poison = 8% max-HP
+per turn until cured, `magic.md:1392`) is already canon in
+`status_effects.gd` / `StatusEffects.resolve_duration`.
+
+### 2.6 AoE-on-death (Shard Burst) — non-elemental, `spell_power: 9`
+
+`palette-families.md:90` gives only *"Shard Burst (AoE on death)"* — element,
+power, and status all silent. It resolves as a `target:"all"`, `type:"magic"`,
+`aoe_on_death:true` ability at the §2.3 AoE power (`spell_power 9`), element
+**non-elemental** (`""`). Non-elemental is chosen because the burst's element
+is undefined and non-elemental avoids inventing a party-resistance interaction
+the docs never specify. It deals no status.
+
+### 2.7 Multi-hit — `hits`
+
+`hits` repeats the ability's damage step N times (each hit rolls its own
+hit/evasion/crit). **No Act I regular enemy is documented with a multi-hit
+ability** — the first is the Act II Cave Vermin's *Rabid Frenzy* (2-hit). The
+engine therefore *supports* `hits > 1` (covered by tests) but no Act I
+production entry sets it above 1.
+
+---
+
+## 3. Out of scope (tracked separately)
+
+These Act I kit items reference mechanics the docs do not yet define; they are
+**deferred** and filed as issues rather than guessed at here:
+
+- **Paralysis** (Ley Jellyfish *Ley Sting*) — referenced by
+  `palette-families.md:275` and `act-i.md:106` but **absent** from the
+  `magic.md` Status Effect Reference. A status definition is required before it
+  can be implemented.
+- **Bespoke effects** with no defined magnitude: HP drain (Latch), self-destruct
+  (Bloat), first-strike (Ambush), knockback (Charge), reactive counter (Thorn
+  Counter), gold theft (Steal Gold), flee (Flee), random-target (Drift).
+- **The full Act I roster.** GAP-024's first pass populates a representative
+  subset proving each mechanic end-to-end; the remaining family kits are
+  populated in a follow-up using the conventions above.

--- a/docs/story/bestiary/enemy-ability-conventions.md
+++ b/docs/story/bestiary/enemy-ability-conventions.md
@@ -68,11 +68,12 @@ matches the Act I regular-enemy band (`palette-families.md` Tier 1 kits).
 
 ### 2.3 AoE elemental abilities — `spell_power: 9`
 
-Party-wide elemental abilities (Frost Burst, Shard Burst) use `spell_power 9`.
+Party-wide elemental abilities (Frost Burst) use `spell_power 9`.
 `magic.md:101` states *"AoE spell power uses approximately 60–70% of the
 single-target ranges."* Applying 65% to the Tier 1 single-target floor of 14
 (§2.2) gives `round(14 × 0.65) = 9`. There is **no damage splitting** — each
-party member takes the full AoE hit (combat-formulas.md:633).
+party member takes the full AoE hit (combat-formulas.md:633). (Shard Burst is a
+*non-elemental* AoE-on-death — see §2.6 — but uses this same AoE power.)
 
 ### 2.4 Stat buffs — reuse the player-analog magnitude & duration
 
@@ -87,8 +88,11 @@ with the same effect (its magnitude and duration are canon):
 | Elemental Shield | MDEF | ×1.40 | 5 turns | Wardglass +40% MDEF / 5t (`magic.md:801`) |
 
 `scope` is `"self"` (buffs only the caster) or `"pack"` (buffs every living
-enemy sharing the caster's `type`, e.g. Pack Howl across all Beasts/wolves in
-the encounter, per `palette-families.md:435` *"ATK up for all wolves"*).
+enemy sharing the caster's **`id`** — its own kind, e.g. Pack Howl across all
+Wayward Wolves in the encounter, per `palette-families.md:435` *"ATK up for all
+wolves"*). Matching by `id` rather than `type` avoids buffing unrelated
+same-type enemies (a Pack Howl should not strengthen the boars and serpents
+sharing a Beast-type encounter).
 
 ### 2.5 Offensive status hit-rate — `status_rate: 70`
 

--- a/docs/story/bestiary/enemy-ability-conventions.md
+++ b/docs/story/bestiary/enemy-ability-conventions.md
@@ -62,8 +62,8 @@ stat already encodes its role (a Boar's high ATK makes Gore hit hard at
 
 Magic-typed single-target enemy abilities (Flicker = Flame, Spark = Ley,
 Shadow Touch = magic) use `spell_power 14`, the documented **Tier 1
-single-target spell power floor** for player attack spells (Cinder
-`magic.md:152`, Frostbite `magic.md:198` — both *Spell power 14*). Tier 1
+single-target spell power floor** for player attack spells (Ember Lance
+`magic.md:152`, Rime Shard `magic.md:198` — both *Spell power 14*). Tier 1
 matches the Act I regular-enemy band (`palette-families.md` Tier 1 kits).
 
 ### 2.3 AoE elemental abilities — `spell_power: 9`

--- a/docs/story/postgame.md
+++ b/docs/story/postgame.md
@@ -199,7 +199,7 @@ you've seen?"
 
 | Category | What It Tracks | Denominator |
 |----------|---------------|-------------|
-| **Bestiary** | Unique enemies encountered (at least one battle) | 235 (per [bestiary/README.md](bestiary/README.md): 25 Act I + 33 Act II + 52 Interlude + 69 Act III + 25 Optional + 31 Bosses) |
+| **Bestiary** | Unique enemies encountered (at least one battle) | 237 (per [bestiary/README.md](bestiary/README.md): 27 Act I + 33 Act II + 52 Interlude + 69 Act III + 25 Optional + 31 Bosses) |
 | **Treasure** | Chests opened across all dungeons and overworld | Total chest count (implementation-defined per dungeon layouts) |
 | **Quests** | Sidequests completed | Total sidequest count per [sidequests.md](sidequests.md) |
 | **Items** | Unique items obtained at least once (consumables, equipment, key items, materials) | Total unique item count across [items.md](items.md) and [equipment.md](equipment.md) |

--- a/game/data/enemies/act_i.json
+++ b/game/data/enemies/act_i.json
@@ -167,7 +167,10 @@
         "ember_vein_f2",
         "ember_vein_f3"
       ],
-      "ko_sound": "ko_elemental"
+      "ko_sound": "ko_elemental",
+      "abilities": [
+        {"id": "shard_burst", "name": "Shard Burst", "type": "magic", "element": "", "spell_power": 9, "target": "all", "aoe_on_death": true, "_comment": "AoE-on-death, non-elemental, spell_power 9 (conventions §2.3/§2.6; magic.md:101,152; palette-families.md:90)"}
+      ]
     },
     {
       "id": "mine_shade",
@@ -299,7 +302,10 @@
       "locations": [
         "ember_vein_f3"
       ],
-      "ko_sound": "ko_elemental"
+      "ko_sound": "ko_elemental",
+      "abilities": [
+        {"id": "flicker", "name": "Flicker", "type": "magic", "element": "flame", "spell_power": 14, "target": "single", "_comment": "single-target Flame; Tier-1 spell_power 14 (conventions §2.2; magic.md:152; palette-families.md:150)"}
+      ]
     },
     {
       "id": "the_flickering",
@@ -382,7 +388,11 @@
         "fenmothers_hollow_f2",
         "fenmothers_hollow_f3"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {"id": "fang_strike", "name": "Fang Strike", "type": "attack", "element": "", "ability_mult": 1.0, "target": "single", "_comment": "basic physical, ability_mult 1.0 (enemy-ability-conventions.md §2.1; palette-families.md:205)"},
+        {"id": "venom_spit", "name": "Venom Spit", "type": "attack", "element": "", "ability_mult": 1.0, "target": "single", "status": "poison", "status_rate": 70, "_comment": "Poison on hit; rate 70 (conventions §2.5; magic.md:107); Poison 8%/turn until cured (magic.md:1392); palette-families.md:205"}
+      ]
     },
     {
       "id": "bog_leech",
@@ -595,7 +605,11 @@
         "fenmothers_hollow_f2",
         "fenmothers_hollow_f3"
       ],
-      "ko_sound": "ko_elemental"
+      "ko_sound": "ko_elemental",
+      "abilities": [
+        {"id": "frost_burst", "name": "Frost Burst", "type": "magic", "element": "frost", "spell_power": 9, "target": "all", "_comment": "AoE Frost; spell_power 9 ~=65% of Tier-1 single 14 (conventions §2.3; magic.md:101,198; palette-families.md:292)"},
+        {"id": "elemental_shield", "name": "Elemental Shield", "type": "buff", "target": "self", "buff": {"stat": "mdef", "mult": 1.40, "duration": 5, "scope": "self"}, "_comment": "MDEF +40%/5t self; Wardglass analog (conventions §2.4; magic.md:801; palette-families.md:292)"}
+      ]
     },
     {
       "id": "corrupted_spawn",
@@ -868,7 +882,11 @@
         "valdris_forest",
         "duskfen_road"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {"id": "bite", "name": "Bite", "type": "attack", "element": "", "ability_mult": 1.0, "target": "single", "_comment": "basic physical (conventions §2.1; palette-families.md:435)"},
+        {"id": "pack_howl", "name": "Pack Howl", "type": "buff", "target": "self", "buff": {"stat": "atk", "mult": 1.30, "duration": 5, "scope": "pack"}, "_comment": "ATK +30%/5t to all wolves; Rallying Cry analog (conventions §2.4; magic.md:834; palette-families.md:435)"}
+      ]
     },
     {
       "id": "compact_patrol",

--- a/game/scripts/combat/battle_actions.gd
+++ b/game/scripts/combat/battle_actions.gd
@@ -272,11 +272,14 @@ static func execute_enemy_physical_ability(
 ) -> Dictionary:
 	var total: int = 0
 	var landed: int = 0
-	var dtype: String = "physical"
+	var any_crit: bool = false
 	for _h: int in range(maxi(1, hits)):
 		var r: Dictionary = execute_enemy_attack(state, enemy, target_slot, ability_mult)
 		if r.get("hit", false):
 			landed += 1
 			total += int(r.get("damage", 0))
-			dtype = r.get("type", "physical")
+			if r.get("type", "") == "critical":
+				any_crit = true
+	# Report "critical" if ANY sub-hit crit, not just the last (which could miss).
+	var dtype: String = "critical" if any_crit else "physical"
 	return {"hit": landed > 0, "damage": total, "type": dtype, "hits_landed": landed}

--- a/game/scripts/combat/battle_actions.gd
+++ b/game/scripts/combat/battle_actions.gd
@@ -44,6 +44,60 @@ static func apply_status_to_enemy(
 	return {"hit": true, "inflicted": true, "type": "status", "status": status_name}
 
 
+## Resolve an enemy offensive status against a party member (GAP-024).
+## Mirror of apply_status_to_enemy, enemy->party: the enemy's MAG drives the
+## two-stage roll's Stage 1, the member's MDEF/SPD drive resistance. Reuses
+## DamageCalc.roll_status + StatusEffects.resolve_duration (no duplication).
+## Returns {hit, inflicted, type, status}; type is
+## "status" | "resisted" | "no_effect".
+static func execute_enemy_status(
+	state: Node,
+	enemy: Node,
+	target_slot: int,
+	base_rate: int,
+	status_name: String,
+	explicit_duration: Variant
+) -> Dictionary:
+	var member: Dictionary = state.get_member(target_slot)
+	var alive: bool = not member.is_empty() and member.get("is_alive", false)
+	if not alive or not StatusEffects.is_known(status_name):
+		return {"hit": false, "inflicted": false, "type": "no_effect", "status": status_name}
+	var caster_mag: int = enemy.get_stats().get("mag", 0)
+	var target_mdef: int = state.get_effective_stat(target_slot, "mdef")
+	var target_spd: int = state.get_effective_stat(target_slot, "spd")
+	if not DamageCalc.roll_status(base_rate, caster_mag, target_mdef, target_spd):
+		return {"hit": false, "inflicted": false, "type": "resisted", "status": status_name}
+	var duration: int = StatusEffects.resolve_duration(status_name, explicit_duration)
+	state.apply_status(target_slot, status_name, "turns", float(duration))
+	return {"hit": true, "inflicted": true, "type": "status", "status": status_name}
+
+
+## Return the enemy's aoe_on_death ability dict, or {} if it has none.
+## (e.g. Unstable Crystal's Shard Burst, per enemy-ability-conventions.md §2.6).
+static func enemy_aoe_on_death_ability(enemy: Node) -> Dictionary:
+	for ab: Dictionary in enemy.enemy_data.get("abilities", []):
+		if ab.get("aoe_on_death", false):
+			return ab
+	return {}
+
+
+## Fire an aoe_on_death ability against the whole living party when its bearer
+## dies. Resolves through execute_enemy_magic (non-elemental by default; element
+## is cosmetic until party resistances exist). Returns per-slot
+## [{slot, damage, type}] so the battle layer can emit damage signals.
+static func execute_aoe_on_death(state: Node, enemy: Node, ability: Dictionary) -> Array:
+	var results: Array = []
+	var element: String = ability.get("element", "")
+	var power: int = int(ability.get("spell_power", ability.get("power", 0)))
+	for i: int in range(4):
+		var m: Dictionary = state.get_member(i)
+		if m.is_empty() or not m.get("is_alive", false):
+			continue
+		var r: Dictionary = execute_enemy_magic(state, enemy, i, element, power)
+		results.append({"slot": i, "damage": r.get("damage", 0), "type": r.get("type", "miss")})
+	return results
+
+
 ## Map a UI cursor index (0..living-1) to an actual _enemies array index.
 ## Returns -1 if no living enemies.
 static func resolve_enemy_target(cursor: int, enemies: Array[Node]) -> int:
@@ -161,7 +215,11 @@ static func execute_enemy_magic(
 
 
 ## Execute an enemy physical attack against a party member.
-static func execute_enemy_attack(state: Node, enemy: Node, target_slot: int) -> Dictionary:
+## [param ability_mult] scales base power (1.0 = basic attack; ability kits set
+## higher per enemy-ability-conventions.md §2.1).
+static func execute_enemy_attack(
+	state: Node, enemy: Node, target_slot: int, ability_mult: float = 1.0
+) -> Dictionary:
 	var stats: Dictionary = enemy.get_stats()
 	var atk: int = stats.get("atk", 10)
 	var spd: int = stats.get("spd", 10)
@@ -187,7 +245,7 @@ static func execute_enemy_attack(state: Node, enemy: Node, target_slot: int) -> 
 		DamageCalc
 		. calculate_physical(
 			atk,
-			1.0,
+			ability_mult,
 			target_def,
 			is_crit,
 			1.0,
@@ -202,3 +260,23 @@ static func execute_enemy_attack(state: Node, enemy: Node, target_slot: int) -> 
 	state.take_damage(target_slot, dmg)
 	var dtype: String = "critical" if is_crit else "physical"
 	return {"hit": true, "damage": dmg, "type": dtype}
+
+
+## Resolve a possibly multi-hit enemy physical ability against one member.
+## Each hit rolls its own hit/evasion/crit (per enemy-ability-conventions.md
+## §2.7). Returns the aggregate {hit, damage, type, hits_landed}. No Act I
+## production enemy sets hits > 1 (first is the Act II Cave Vermin); the engine
+## supports it and this path is test-covered.
+static func execute_enemy_physical_ability(
+	state: Node, enemy: Node, target_slot: int, ability_mult: float = 1.0, hits: int = 1
+) -> Dictionary:
+	var total: int = 0
+	var landed: int = 0
+	var dtype: String = "physical"
+	for _h: int in range(maxi(1, hits)):
+		var r: Dictionary = execute_enemy_attack(state, enemy, target_slot, ability_mult)
+		if r.get("hit", false):
+			landed += 1
+			total += int(r.get("damage", 0))
+			dtype = r.get("type", "physical")
+	return {"hit": landed > 0, "damage": total, "type": dtype, "hits_landed": landed}

--- a/game/scripts/combat/battle_ai.gd
+++ b/game/scripts/combat/battle_ai.gd
@@ -27,10 +27,14 @@ static func select_action(
 		var target: int = _pick_physical_target(living, party_rows)
 		return {"type": "attack", "target_slot": target, "ability_id": ""}
 
-	# 20% ability (if enemy has any). A chosen-but-empty ability list falls
+	# 20% ability (if enemy has any). aoe_on_death abilities (Shard Burst) are
+	# death triggers only — they fire via _on_enemy_died, never as a turn action,
+	# so exclude them from the selectable pool. A chosen-but-empty list falls
 	# through to defend (the pre-GAP-024 behavior when no enemy had abilities).
 	if roll < 90:
-		var abilities: Array = enemy_data.get("abilities", [])
+		var abilities: Array = enemy_data.get("abilities", []).filter(
+			func(a: Dictionary) -> bool: return not a.get("aoe_on_death", false)
+		)
 		if not abilities.is_empty():
 			var ab: Dictionary = abilities[randi() % abilities.size()]
 			return _build_ability_action(ab, living, party_rows)

--- a/game/scripts/combat/battle_ai.gd
+++ b/game/scripts/combat/battle_ai.gd
@@ -27,16 +27,43 @@ static func select_action(
 		var target: int = _pick_physical_target(living, party_rows)
 		return {"type": "attack", "target_slot": target, "ability_id": ""}
 
-	# 20% ability (if enemy has any)
+	# 20% ability (if enemy has any). A chosen-but-empty ability list falls
+	# through to defend (the pre-GAP-024 behavior when no enemy had abilities).
 	if roll < 90:
 		var abilities: Array = enemy_data.get("abilities", [])
 		if not abilities.is_empty():
 			var ab: Dictionary = abilities[randi() % abilities.size()]
-			var target: int = living[randi() % living.size()]
-			return {"type": "ability", "target_slot": target, "ability_id": ab.get("id", "")}
+			return _build_ability_action(ab, living, party_rows)
 
 	# 10% defend / do nothing
 	return {"type": "defend", "target_slot": -1, "ability_id": ""}
+
+
+## Build a turn action from an enemy ability dict (GAP-024). Propagates the full
+## ability metadata (target shape, element/power, status, multi-hit, buff) so the
+## turn driver can resolve it — not just the id. See
+## docs/story/bestiary/enemy-ability-conventions.md for the schema.
+static func _build_ability_action(ab: Dictionary, living: Array, party_rows: Array) -> Dictionary:
+	var shape: String = ab.get("target", "single")
+	var action: Dictionary = {
+		"type": "ability",
+		"id": ab.get("id", ""),
+		"ability_id": ab.get("id", ""),
+		"target": shape,
+		"atk_type": ab.get("type", "attack"),
+		"element": ab.get("element", ""),
+		"power": int(ab.get("spell_power", 0)),
+		"ability_mult": float(ab.get("ability_mult", 1.0)),
+		"status": ab.get("status", ""),
+		"status_rate": int(ab.get("status_rate", 0)),
+		"status_duration": ab.get("status_duration", null),
+		"hits": int(ab.get("hits", 1)),
+		"buff": ab.get("buff", {}),
+		"aoe_on_death": bool(ab.get("aoe_on_death", false)),
+	}
+	# Only single-target abilities resolve a concrete slot; all/self do not.
+	action["target_slot"] = _pick_physical_target(living, party_rows) if shape == "single" else -1
+	return action
 
 
 ## Select boss action (stub — returns basic attack).

--- a/game/scripts/combat/battle_enemy_turn.gd
+++ b/game/scripts/combat/battle_enemy_turn.gd
@@ -173,8 +173,9 @@ func _tick_enemy_statuses(enemy: Node, idx: int) -> void:
 
 
 ## Resolve a self-targeted ability (GAP-024): apply its stat buff. scope "pack"
-## buffs every living enemy of the caster's type (Pack Howl across all wolves,
-## palette-families.md:435); "self" buffs only the caster.
+## buffs every living enemy of the caster's own kind (same enemy id — Pack Howl
+## across all Wayward Wolves, palette-families.md:435); "self" buffs only the
+## caster.
 func _do_self_ability(action: Dictionary, enemy: Node, enemies: Array[Node]) -> void:
 	_manager.message.emit("%s uses %s!" % [enemy.get_display_name(), action.get("id", "")])
 	var buff: Dictionary = action.get("buff", {})

--- a/game/scripts/combat/battle_enemy_turn.gd
+++ b/game/scripts/combat/battle_enemy_turn.gd
@@ -136,7 +136,7 @@ func _apply_action(action: Dictionary, enemy: Node, enemies: Array[Node], idx: i
 		_do_skip(action, enemy, idx)
 		return
 	if atype == "ability" and action.get("target", "") == "self":
-		_manager.message.emit("%s uses %s!" % [enemy.get_display_name(), action.get("id", "")])
+		_do_self_ability(action, enemy, enemies)
 		_tick_enemy_statuses(enemy, idx)
 		return
 	if atype == "heal" and action.get("target", "") == "self":
@@ -169,6 +169,26 @@ func _tick_enemy_statuses(enemy: Node, idx: int) -> void:
 				_manager.combatant_died.emit(eid)
 				_atb.remove_combatant(eid)
 	enemy.tick_statuses()
+	enemy.tick_buffs()
+
+
+## Resolve a self-targeted ability (GAP-024): apply its stat buff. scope "pack"
+## buffs every living enemy of the caster's type (Pack Howl across all wolves,
+## palette-families.md:435); "self" buffs only the caster.
+func _do_self_ability(action: Dictionary, enemy: Node, enemies: Array[Node]) -> void:
+	_manager.message.emit("%s uses %s!" % [enemy.get_display_name(), action.get("id", "")])
+	var buff: Dictionary = action.get("buff", {})
+	if buff.is_empty():
+		return
+	var stat: String = buff.get("stat", "")
+	var mult: float = float(buff.get("mult", 1.0))
+	var duration: int = int(buff.get("duration", 5))
+	if buff.get("scope", "self") == "pack":
+		for e: Node in enemies:
+			if e.is_alive and e.get_type() == enemy.get_type():
+				e.apply_buff(stat, mult, duration)
+	else:
+		enemy.apply_buff(stat, mult, duration)
 
 
 func _do_spawn(action: Dictionary, enemy: Node, enemies: Array[Node], idx: int) -> void:
@@ -182,6 +202,7 @@ func _do_spawn(action: Dictionary, enemy: Node, enemies: Array[Node], idx: int) 
 		enemies.append(new_enemy)
 		var eid: String = "enemy_%d" % (enemies.size() - 1)
 		_atb.add_combatant(eid, new_enemy.get_stats().get("spd", 10), true)
+		new_enemy.died.connect(_manager._on_enemy_died.bind(new_enemy))
 	_manager.message.emit("Corrupted Spawns emerge from the depths!")
 	_tick_enemy_statuses(enemy, idx)
 
@@ -239,16 +260,42 @@ func _do_attack_or_ability(action: Dictionary, enemy: Node, _idx: int) -> void:
 			return
 		var tgt_name: String = _state.get_member(tgt).get("character_data", {}).get("name", "???")
 		_manager.message.emit("%s attacks %s!" % [enemy.get_display_name(), tgt_name])
-		var result: Dictionary = BattleActions.execute_enemy_attack(_state, enemy, tgt)
-		(
-			_manager
-			. damage_dealt
-			. emit(
-				"party_%d" % tgt,
-				result.get("damage", 0),
-				result.get("type", "miss"),
+		var result: Dictionary
+		# Magic abilities (atk_type "magic") use the MAG formula; everything else
+		# (basic attacks, physical abilities, legacy boss abilities) is physical.
+		# A plain attack is execute_enemy_physical_ability(mult 1.0, hits 1).
+		if action.get("atk_type", "attack") == "magic":
+			result = BattleActions.execute_enemy_magic(
+				_state, enemy, tgt, elem, int(action.get("power", 0))
 			)
+		else:
+			result = (
+				BattleActions
+				. execute_enemy_physical_ability(
+					_state,
+					enemy,
+					tgt,
+					float(action.get("ability_mult", 1.0)),
+					int(action.get("hits", 1)),
+				)
+			)
+		_manager.damage_dealt.emit(
+			"party_%d" % tgt, result.get("damage", 0), result.get("type", "miss")
 		)
+		# Offensive status infliction on a landed hit (GAP-024, Venom Spit -> Poison).
+		var status_name: String = action.get("status", "")
+		if not status_name.is_empty() and result.get("hit", false):
+			(
+				BattleActions
+				. execute_enemy_status(
+					_state,
+					enemy,
+					tgt,
+					int(action.get("status_rate", 0)),
+					status_name,
+					action.get("status_duration"),
+				)
+			)
 	# Gain Weave Gauge for Maren AFTER action resolves (not before target validation)
 	if atype == "ability":
 		_state.gain_weave_gauge_for_maren(15)

--- a/game/scripts/combat/battle_enemy_turn.gd
+++ b/game/scripts/combat/battle_enemy_turn.gd
@@ -184,8 +184,12 @@ func _do_self_ability(action: Dictionary, enemy: Node, enemies: Array[Node]) -> 
 	var mult: float = float(buff.get("mult", 1.0))
 	var duration: int = int(buff.get("duration", 5))
 	if buff.get("scope", "self") == "pack":
+		# "pack" = the caster's own kind (same enemy id), e.g. all Wayward Wolves
+		# in the encounter (palette-families.md:435 "all wolves") — NOT every
+		# same-type beast, which would buff boars/serpents sharing the fight.
+		var pack_id: String = enemy.enemy_data.get("id", "")
 		for e: Node in enemies:
-			if e.is_alive and e.get_type() == enemy.get_type():
+			if e.is_alive and e.enemy_data.get("id", "") == pack_id:
 				e.apply_buff(stat, mult, duration)
 	else:
 		enemy.apply_buff(stat, mult, duration)
@@ -235,16 +239,12 @@ func _do_attack_or_ability(action: Dictionary, enemy: Node, _idx: int) -> void:
 				)
 			)
 		)
+		var status_name: String = action.get("status", "")
 		for i: int in range(4):
 			var m: Dictionary = _state.get_member(i)
 			if m.is_empty() or not m.get("is_alive", false):
 				continue
-			var result: Dictionary
-			if not elem.is_empty():
-				var pwr: int = action.get("power", 10)
-				result = BattleActions.execute_enemy_magic(_state, enemy, i, elem, pwr)
-			else:
-				result = BattleActions.execute_enemy_attack(_state, enemy, i)
+			var result: Dictionary = _resolve_offensive(action, enemy, i, elem)
 			(
 				_manager
 				. damage_dealt
@@ -254,6 +254,18 @@ func _do_attack_or_ability(action: Dictionary, enemy: Node, _idx: int) -> void:
 					result.get("type", "miss"),
 				)
 			)
+			if not status_name.is_empty() and result.get("hit", false):
+				(
+					BattleActions
+					. execute_enemy_status(
+						_state,
+						enemy,
+						i,
+						int(action.get("status_rate", 0)),
+						status_name,
+						action.get("status_duration"),
+					)
+				)
 	else:
 		var tgt: int = action.get("target_slot", 0)
 		if tgt < 0:
@@ -299,3 +311,19 @@ func _do_attack_or_ability(action: Dictionary, enemy: Node, _idx: int) -> void:
 	# Gain Weave Gauge for Maren AFTER action resolves (not before target validation)
 	if atype == "ability":
 		_state.gain_weave_gauge_for_maren(15)
+
+
+## Resolve one offensive AoE hit against a party slot. Magic when atk_type is
+## "magic" OR the action carries an element (the latter preserves legacy boss
+## AoEs — ember_pulse/frost_wave — which route by element with no atk_type);
+## otherwise physical, with ability_mult + multi-hit support. The single-target
+## branch deliberately keeps its atk_type-only routing so legacy water_jet stays
+## physical (boss AI is GAP-009 scope).
+func _resolve_offensive(action: Dictionary, enemy: Node, slot: int, elem: String) -> Dictionary:
+	if action.get("atk_type", "") == "magic" or not elem.is_empty():
+		return BattleActions.execute_enemy_magic(
+			_state, enemy, slot, elem, int(action.get("power", 0))
+		)
+	return BattleActions.execute_enemy_physical_ability(
+		_state, enemy, slot, float(action.get("ability_mult", 1.0)), int(action.get("hits", 1))
+	)

--- a/game/scripts/combat/battle_manager.gd
+++ b/game/scripts/combat/battle_manager.gd
@@ -188,7 +188,12 @@ func _on_ui_command(command: Dictionary) -> void:
 	_awaiting_input_for = ""
 	_atb.reset_gauge(actor_id)
 	_turn_counter += 1
-	_state.tick_statuses(actor_id.replace("party_", "").to_int())
+	# Surface party-side DoT (Poison/Burn) through damage_dealt so it shows a
+	# floating number, mirroring the enemy-side tick.
+	for ev: Dictionary in _state.tick_statuses(cmd_slot):
+		damage_dealt.emit(
+			"party_%d" % int(ev.get("slot", 0)), int(ev.get("dmg", 0)), ev.get("type", "poison")
+		)
 	_check_end_conditions()
 
 

--- a/game/scripts/combat/battle_manager.gd
+++ b/game/scripts/combat/battle_manager.gd
@@ -204,6 +204,19 @@ func _on_party_member_died(slot: int) -> void:
 		_atb.set_command_menu_open(false)
 
 
+## AoE-on-death hook (GAP-024). When an enemy with an aoe_on_death ability dies
+## — by player attack, spell, or DoT — it bursts against the whole party.
+func _on_enemy_died(enemy: Node) -> void:
+	var ability: Dictionary = BattleActions.enemy_aoe_on_death_ability(enemy)
+	if ability.is_empty():
+		return
+	message.emit("%s bursts apart!" % enemy.get_display_name())
+	for r: Dictionary in BattleActions.execute_aoe_on_death(_state, enemy, ability):
+		damage_dealt.emit(
+			"party_%d" % int(r.get("slot", 0)), int(r.get("damage", 0)), r.get("type", "miss")
+		)
+
+
 func _do_attack(actor_id: String, command: Dictionary) -> bool:
 	var slot: int = actor_id.replace("party_", "").to_int()
 	var target_idx: int = BattleActions.resolve_enemy_target(command.get("target", 0), _enemies)
@@ -624,3 +637,5 @@ func _setup_enemies(encounter_group: Array, enemy_act: String) -> void:
 		e.position = Vector2(160.0 + (i % 3) * 48.0, 40.0 + floorf(i / 3.0) * 48.0)
 		_enemies.append(e)
 		_atb.add_combatant("enemy_%d" % i, e.get_stats().get("spd", 10), true)
+		# AoE-on-death (Shard Burst): fire when this enemy dies, by any cause.
+		e.died.connect(_on_enemy_died.bind(e))

--- a/game/scripts/combat/battle_state.gd
+++ b/game/scripts/combat/battle_state.gd
@@ -174,12 +174,14 @@ func has_status(slot: int, status_name: String) -> bool:
 
 ## Tick turn-based statuses at END of a combatant's turn. Applies Poison/Burn
 ## HP ticks first, then decrements durations. UNTIL_CURED (negative) durations
-## persist — they are cured by remove_status, never by countdown.
-func tick_statuses(slot: int) -> void:
+## persist — they are cured by remove_status, never by countdown. Returns the
+## DoT events [{slot, dmg, type}] so the battle layer can emit damage feedback
+## (mirrors the enemy-side tick's damage_dealt emission).
+func tick_statuses(slot: int) -> Array:
 	var m: Dictionary = get_member(slot)
 	if m.is_empty():
-		return
-	_apply_dot(slot, m)
+		return []
+	var dot_events: Array = _apply_dot(slot, m)
 	for i: int in range(m["active_statuses"].size() - 1, -1, -1):
 		var s: Dictionary = m["active_statuses"][i]
 		if s.get("duration_type", "") != "turns":
@@ -192,19 +194,28 @@ func tick_statuses(slot: int) -> void:
 			var sname: String = s.get("name", "")
 			m["active_statuses"].remove_at(i)
 			status_removed.emit(slot, sname)
+	return dot_events
 
 
 ## Apply damage-over-time (Poison 8%/turn magic.md:1392, Burn 5%/turn) to a
 ## member. Mirrors the enemy-side tick: floor(max_hp * tick_pct), min 1. DoT does
-## not wake-cure here (party has no Sleep/Confusion infliction yet).
-func _apply_dot(slot: int, m: Dictionary) -> void:
+## not wake-cure here (party has no Sleep/Confusion infliction yet). Returns the
+## per-status events [{slot, dmg, type}] for damage feedback.
+func _apply_dot(slot: int, m: Dictionary) -> Array:
+	var events: Array = []
 	if not m.get("is_alive", false):
-		return
+		return events
 	var max_hp: int = m.get("max_hp", 0)
 	for s: Dictionary in (m["active_statuses"] as Array).duplicate():
-		var pct: float = StatusEffects.tick_pct(s.get("name", ""))
+		var sname: String = s.get("name", "")
+		var pct: float = StatusEffects.tick_pct(sname)
 		if pct > 0.0 and m.get("is_alive", false):
-			take_damage(slot, maxi(1, int(max_hp * pct)))
+			var dmg: int = maxi(1, int(max_hp * pct))
+			take_damage(slot, dmg)
+			events.append(
+				{"slot": slot, "dmg": dmg, "type": "burn" if sname == "burn" else "poison"}
+			)
+	return events
 
 
 ## Tick real-time statuses (Stop). Called from _process with delta.

--- a/game/scripts/combat/battle_state.gd
+++ b/game/scripts/combat/battle_state.gd
@@ -11,6 +11,8 @@ signal member_revived(slot: int)
 signal status_applied(slot: int, status_name: String)
 signal status_removed(slot: int, status_name: String)
 
+const StatusEffects = preload("res://scripts/combat/status_effects.gd")
+
 ## Party member data. Index = slot (0-3). Null entries = empty slots.
 var _members: Array = [null, null, null, null]
 
@@ -170,20 +172,39 @@ func has_status(slot: int, status_name: String) -> bool:
 	return false
 
 
-## Tick turn-based statuses at END of a combatant's turn.
+## Tick turn-based statuses at END of a combatant's turn. Applies Poison/Burn
+## HP ticks first, then decrements durations. UNTIL_CURED (negative) durations
+## persist — they are cured by remove_status, never by countdown.
 func tick_statuses(slot: int) -> void:
 	var m: Dictionary = get_member(slot)
 	if m.is_empty():
 		return
+	_apply_dot(slot, m)
 	for i: int in range(m["active_statuses"].size() - 1, -1, -1):
 		var s: Dictionary = m["active_statuses"][i]
 		if s.get("duration_type", "") != "turns":
+			continue
+		# Negative remaining_turns = UNTIL_CURED (Poison): never decremented.
+		if int(s.get("remaining_turns", 0)) < 0:
 			continue
 		s["remaining_turns"] -= 1
 		if s["remaining_turns"] <= 0:
 			var sname: String = s.get("name", "")
 			m["active_statuses"].remove_at(i)
 			status_removed.emit(slot, sname)
+
+
+## Apply damage-over-time (Poison 8%/turn magic.md:1392, Burn 5%/turn) to a
+## member. Mirrors the enemy-side tick: floor(max_hp * tick_pct), min 1. DoT does
+## not wake-cure here (party has no Sleep/Confusion infliction yet).
+func _apply_dot(slot: int, m: Dictionary) -> void:
+	if not m.get("is_alive", false):
+		return
+	var max_hp: int = m.get("max_hp", 0)
+	for s: Dictionary in (m["active_statuses"] as Array).duplicate():
+		var pct: float = StatusEffects.tick_pct(s.get("name", ""))
+		if pct > 0.0 and m.get("is_alive", false):
+			take_damage(slot, maxi(1, int(max_hp * pct)))
 
 
 ## Tick real-time statuses (Stop). Called from _process with delta.

--- a/game/scripts/entities/enemy.gd
+++ b/game/scripts/entities/enemy.gd
@@ -58,6 +58,10 @@ var current_mp: int = 0
 ## Active status effects: [{name: String, remaining_turns: int}].
 var active_statuses: Array[Dictionary] = []
 
+## Active stat buffs (GAP-024): [{stat: String, mult: float, remaining_turns: int}].
+## Applied multiplicatively in get_stats(); ticked down at end of turn.
+var active_buffs: Array[Dictionary] = []
+
 ## Whether the enemy is still alive. Defaults false until initialize().
 var is_alive: bool = false
 
@@ -73,6 +77,7 @@ func initialize(p_enemy_id: String, p_act: String) -> void:
 	current_hp = 0
 	current_mp = 0
 	active_statuses.clear()
+	active_buffs.clear()
 	is_alive = false
 
 	enemy_id = p_enemy_id
@@ -106,8 +111,36 @@ func get_stats() -> Dictionary:
 	]
 	var stats: Dictionary = {}
 	for key: String in stat_keys:
-		stats[key] = enemy_data.get(key, 0)
+		var base: int = enemy_data.get(key, 0)
+		var mult: float = buff_mult(key)
+		stats[key] = int(base * mult) if mult != 1.0 else base
 	return stats
+
+
+## Apply a stat buff (GAP-024). Replaces any existing buff on the same stat
+## (refresh, no stacking), per enemy-ability-conventions.md §2.4.
+func apply_buff(stat: String, mult: float, duration: int) -> void:
+	for i: int in range(active_buffs.size() - 1, -1, -1):
+		if active_buffs[i].get("stat", "") == stat:
+			active_buffs.remove_at(i)
+	active_buffs.append({"stat": stat, "mult": mult, "remaining_turns": duration})
+
+
+## Combined multiplier for a stat from active buffs (1.0 when none).
+func buff_mult(stat: String) -> float:
+	var product: float = 1.0
+	for b: Dictionary in active_buffs:
+		if b.get("stat", "") == stat:
+			product *= float(b.get("mult", 1.0))
+	return product
+
+
+## Tick buff durations down by 1 at END of the enemy's turn; remove expired.
+func tick_buffs() -> void:
+	for i: int in range(active_buffs.size() - 1, -1, -1):
+		active_buffs[i]["remaining_turns"] -= 1
+		if active_buffs[i]["remaining_turns"] <= 0:
+			active_buffs.remove_at(i)
 
 
 ## Get the enemy type (beast, undead, construct, etc.).

--- a/game/scripts/ui/battle_ui.gd
+++ b/game/scripts/ui/battle_ui.gd
@@ -14,6 +14,8 @@ const COLOR_DAMAGE: Color = Color("#ffffff")
 const COLOR_HEAL: Color = Color("#44ff44")
 const COLOR_MISS: Color = Color("#888888")
 const COLOR_CRIT: Color = Color("#ffff44")
+const COLOR_POISON: Color = Color("#aa66cc")
+const COLOR_BURN: Color = Color("#ff8844")
 
 var _manager: Node = null
 var _battle_state: Node = null
@@ -161,6 +163,10 @@ func _on_damage_dealt(target_id: String, amount: int, damage_type: String) -> vo
 			text = "Immune"
 		"critical":
 			color = COLOR_CRIT
+		"poison":
+			color = COLOR_POISON
+		"burn":
+			color = COLOR_BURN
 
 	_spawn_damage_number(target_id, text, color)
 

--- a/game/tests/test_enemy_abilities.gd
+++ b/game/tests/test_enemy_abilities.gd
@@ -1,0 +1,397 @@
+extends GutTest
+## Tests for enemy abilities (GAP-024): enemy->party offensive status infliction,
+## party-side DoT ticking, multi-hit, AoE-on-death, and pack buffs. Every numeric
+## constant traces to docs/story/bestiary/enemy-ability-conventions.md and the
+## canon it cites (magic.md / combat-formulas.md).
+
+const BattleActions = preload("res://scripts/combat/battle_actions.gd")
+const BattleState = preload("res://scripts/combat/battle_state.gd")
+const BattleAI = preload("res://scripts/combat/battle_ai.gd")
+const StatusEffects = preload("res://scripts/combat/status_effects.gd")
+const ENEMY_SCENE: PackedScene = preload("res://scenes/entities/enemy.tscn")
+const BATTLE: PackedScene = preload("res://scenes/core/battle.tscn")
+
+## Poison: 8% max HP/turn, until cured (magic.md:1392). UNTIL_CURED sentinel = -1.
+const UNTIL_CURED: int = -1
+
+
+func after_each() -> void:
+	# Undo any seed() so determinism doesn't leak into later tests.
+	randomize()
+
+
+## A party state with one member whose defensive stats we control, so the
+## two-stage status roll (DamageCalc.roll_status) is exercised against known
+## MDEF/SPD. mag is irrelevant to the target side but required by add_member.
+func _make_party(mdef: int, spd: int, hp: int = 100) -> Node:
+	var state: Node = BattleState.new()
+	add_child_autofree(state)
+	(
+		state
+		. add_member(
+			0,
+			{
+				"character_id": "tester",
+				"base_stats": {"mag": 10, "mdef": mdef, "spd": spd, "hp": hp, "mp": 0},
+				"max_hp": hp,
+				"current_hp": hp,
+			}
+		)
+	)
+	return state
+
+
+func _make_enemy(enemy_id: String) -> Enemy:
+	var enemy: Enemy = ENEMY_SCENE.instantiate()
+	add_child_autofree(enemy)
+	enemy.initialize(enemy_id, "act_i")
+	return enemy
+
+
+## A synthetic enemy with fully controlled stats (bypasses DataManager) so
+## damage math is deterministic and independent of bestiary tuning.
+func _make_synthetic_enemy(data: Dictionary) -> Enemy:
+	var enemy: Enemy = ENEMY_SCENE.instantiate()
+	add_child_autofree(enemy)
+	enemy.enemy_data = data
+	enemy.current_hp = data.get("hp", 100)
+	enemy.is_alive = enemy.current_hp > 0
+	return enemy
+
+
+## Party state with one member built from an explicit stat dict.
+func _party_with(base_stats: Dictionary, hp: int = 100) -> Node:
+	return _party_members(1, base_stats, hp)
+
+
+## Party state with `count` identical members (slots 0..count-1).
+func _party_members(count: int, base_stats: Dictionary, hp: int = 100) -> Node:
+	var state: Node = BattleState.new()
+	add_child_autofree(state)
+	for i: int in range(count):
+		state.add_member(
+			i, {"character_id": "tester", "base_stats": base_stats, "max_hp": hp, "current_hp": hp}
+		)
+	return state
+
+
+# --- Enemy -> party status infliction (GAP-024) ---
+
+
+func test_enemy_inflicts_status_on_party_member() -> void:
+	# High rate + a high-MAG enemy vs a low-MDEF/SPD party member: the two-stage
+	# roll lands within a few tries. marsh_serpent's Venom Spit delivers Poison.
+	seed(12345)
+	var inflicted_any: bool = false
+	for _i: int in range(30):
+		var state: Node = _make_party(0, 0)
+		var enemy: Enemy = _make_enemy("marsh_serpent")
+		var r: Dictionary = BattleActions.execute_enemy_status(state, enemy, 0, 100, "poison", null)
+		if r.get("inflicted", false):
+			inflicted_any = true
+			assert_eq(r.get("type", ""), "status", "a landed status reports type 'status'")
+			assert_true(state.has_status(0, "poison"), "party member actually carries the status")
+			break
+	assert_true(inflicted_any, "a 100%-rate status should land within 30 attempts")
+
+
+func test_enemy_status_resisted_when_rate_zero() -> void:
+	# base_rate 0 -> Stage 1 effective rate 0 -> always fails. Deterministic.
+	var state: Node = _make_party(10, 10)
+	var enemy: Enemy = _make_enemy("marsh_serpent")
+	var r: Dictionary = BattleActions.execute_enemy_status(state, enemy, 0, 0, "poison", null)
+	assert_false(r.get("inflicted", false), "0% rate never inflicts")
+	assert_eq(r.get("type", ""), "resisted")
+	assert_false(state.has_status(0, "poison"))
+
+
+func test_enemy_status_no_effect_on_dead_member() -> void:
+	var state: Node = _make_party(0, 0, 0)  # hp 0 -> not alive
+	var enemy: Enemy = _make_enemy("marsh_serpent")
+	var r: Dictionary = BattleActions.execute_enemy_status(state, enemy, 0, 100, "poison", null)
+	assert_false(r.get("inflicted", false), "cannot afflict a downed member")
+	assert_eq(r.get("type", ""), "no_effect")
+
+
+func test_enemy_status_unknown_is_no_effect() -> void:
+	# 'paralysis' is undefined (deferred) -> graceful no-op, never inflicted.
+	var state: Node = _make_party(0, 0)
+	var enemy: Enemy = _make_enemy("marsh_serpent")
+	var r: Dictionary = BattleActions.execute_enemy_status(state, enemy, 0, 100, "paralysis", null)
+	assert_eq(r.get("type", ""), "no_effect")
+	assert_false(state.has_status(0, "paralysis"))
+
+
+# --- Party-side damage-over-time (Poison/Burn) ---
+
+
+func test_poison_ticks_party_member_hp() -> void:
+	# Poison = 8% max HP/turn (magic.md:1392). 100 max HP -> 8 per tick, floor 1.
+	var state: Node = _make_party(0, 0, 100)
+	state.apply_status(0, "poison", "turns", UNTIL_CURED)
+	state.tick_statuses(0)
+	var hp: int = state.get_member(0).get("current_hp", 100)
+	assert_eq(hp, 92, "8% of 100 max HP lost to a single poison tick")
+
+
+func test_until_cured_status_is_not_decremented_away() -> void:
+	# A negative (UNTIL_CURED) duration must persist across ticks, like enemy side.
+	var state: Node = _make_party(0, 0, 100)
+	state.apply_status(0, "poison", "turns", UNTIL_CURED)
+	state.tick_statuses(0)
+	state.tick_statuses(0)
+	assert_true(state.has_status(0, "poison"), "until-cured poison survives multiple ticks")
+
+
+# --- ability_mult power knob + multi-hit (GAP-024) ---
+
+
+func test_ability_mult_scales_physical_damage() -> void:
+	# Same seed -> identical hit/evasion/crit/variance rolls, so a higher
+	# ability_mult must yield strictly more damage (raw scales by mult pre-floor).
+	var data: Dictionary = {"atk": 40, "spd": 30, "type": "humanoid", "hp": 100}
+	seed(99)
+	var weak: Dictionary = BattleActions.execute_enemy_attack(
+		_party_with({"def": 5, "spd": 1}), _make_synthetic_enemy(data), 0, 1.0
+	)
+	seed(99)
+	var strong: Dictionary = BattleActions.execute_enemy_attack(
+		_party_with({"def": 5, "spd": 1}), _make_synthetic_enemy(data), 0, 3.0
+	)
+	assert_true(
+		weak.get("hit", false) and strong.get("hit", false), "both hits land at SPD 30 vs 1"
+	)
+	assert_gt(
+		int(strong.get("damage", 0)),
+		int(weak.get("damage", 0)),
+		"ability_mult 3.0 deals more than 1.0 under the same RNG"
+	)
+
+
+func test_multihit_aggregates_damage_and_counts_hits() -> void:
+	# hits=3 against a near-guaranteed-hit target lands multiple times and sums
+	# more damage than a single hit. Enemy SPD >> target SPD keeps misses rare.
+	seed(7)
+	var data: Dictionary = {"atk": 40, "spd": 50, "type": "humanoid", "hp": 100}
+	# 5000 HP so the member survives all three hits (each ~250) and we can count them.
+	var r: Dictionary = BattleActions.execute_enemy_physical_ability(
+		_party_with({"def": 5, "spd": 1}, 5000), _make_synthetic_enemy(data), 0, 1.0, 3
+	)
+	assert_between(int(r.get("hits_landed", 0)), 1, 3, "1-3 of three hits land")
+	assert_gt(int(r.get("hits_landed", 0)), 1, "with SPD 50 vs 1, most of 3 hits connect")
+	assert_true(r.get("hit", false), "aggregate reports a hit when any sub-hit lands")
+
+
+func test_single_hit_default_is_one_hit() -> void:
+	seed(7)
+	var data: Dictionary = {"atk": 40, "spd": 50, "type": "humanoid", "hp": 100}
+	var r: Dictionary = BattleActions.execute_enemy_physical_ability(
+		_party_with({"def": 5, "spd": 1}, 5000), _make_synthetic_enemy(data), 0
+	)
+	assert_eq(int(r.get("hits_landed", 0)), 1, "default hits=1 lands exactly once")
+
+
+# --- AI ability-metadata propagation (GAP-024) ---
+
+
+func test_ai_ability_action_carries_full_metadata() -> void:
+	seed(123)
+	var enemy_data: Dictionary = {
+		"abilities":
+		[
+			{
+				"id": "venom_spit",
+				"name": "Venom Spit",
+				"type": "attack",
+				"status": "poison",
+				"status_rate": 70,
+				"target": "single",
+				"ability_mult": 1.0,
+				"hits": 1,
+			}
+		]
+	}
+	var pm: Array = [{"is_alive": true, "row": "front"}, null, null, null]
+	var pr: Array = ["front", "front", "front", "front"]
+	var found: bool = false
+	for _i: int in range(200):
+		var a: Dictionary = BattleAI.select_action(enemy_data, pm, pr)
+		if a.get("type", "") == "ability":
+			found = true
+			assert_eq(a.get("ability_id", ""), "venom_spit", "carries the ability id")
+			assert_eq(a.get("status", ""), "poison", "carries the inflicted status")
+			assert_eq(int(a.get("status_rate", 0)), 70, "carries the status base-rate")
+			assert_eq(a.get("atk_type", ""), "attack", "carries the resolution type")
+			assert_eq(a.get("target", ""), "single", "carries the target shape")
+			assert_gte(int(a.get("target_slot", -1)), 0, "single-target picks a living slot")
+			break
+	assert_true(found, "the 20% branch yields an ability action within 200 rolls")
+
+
+func test_ai_without_abilities_never_returns_ability() -> void:
+	# The fall-through fix: a chosen-but-empty ability list defends, never
+	# returns a malformed 'ability' action.
+	seed(1)
+	var enemy_data: Dictionary = {"abilities": []}
+	var pm: Array = [{"is_alive": true, "row": "front"}, null, null, null]
+	var pr: Array = ["front", "front", "front", "front"]
+	for _i: int in range(300):
+		var a: Dictionary = BattleAI.select_action(enemy_data, pm, pr)
+		assert_ne(a.get("type", ""), "ability", "no abilities -> never an ability action")
+
+
+# --- Enemy stat buffs (GAP-024) ---
+
+
+func test_enemy_buff_scales_get_stats() -> void:
+	# Pack Howl = +30% ATK (Rallying Cry analog, magic.md:834).
+	var enemy: Enemy = _make_synthetic_enemy({"atk": 20, "type": "beast", "hp": 100})
+	assert_eq(int(enemy.get_stats().get("atk", 0)), 20, "base ATK before buff")
+	enemy.apply_buff("atk", 1.30, 5)
+	assert_eq(int(enemy.get_stats().get("atk", 0)), 26, "20 x 1.30 = 26 after Pack Howl")
+
+
+func test_enemy_buff_refreshes_not_stacks() -> void:
+	var enemy: Enemy = _make_synthetic_enemy({"atk": 20, "type": "beast", "hp": 100})
+	enemy.apply_buff("atk", 1.30, 5)
+	enemy.apply_buff("atk", 1.30, 5)
+	assert_eq(int(enemy.get_stats().get("atk", 0)), 26, "same-stat buff refreshes, not 1.69x stack")
+
+
+func test_enemy_buff_expires_after_duration() -> void:
+	var enemy: Enemy = _make_synthetic_enemy({"atk": 20, "type": "beast", "hp": 100})
+	enemy.apply_buff("atk", 1.30, 1)
+	enemy.tick_buffs()
+	assert_eq(int(enemy.get_stats().get("atk", 0)), 20, "buff gone after its 1-turn duration")
+
+
+# --- AoE-on-death / Shard Burst (GAP-024) ---
+
+
+func test_aoe_on_death_ability_lookup() -> void:
+	var enemy: Enemy = _make_synthetic_enemy(
+		{
+			"mag": 20,
+			"type": "elemental",
+			"hp": 1,
+			"abilities":
+			[
+				{"id": "fang", "type": "attack"},
+				{"id": "shard_burst", "aoe_on_death": true, "type": "magic", "spell_power": 9},
+			],
+		}
+	)
+	var ab: Dictionary = BattleActions.enemy_aoe_on_death_ability(enemy)
+	assert_eq(ab.get("id", ""), "shard_burst", "finds the aoe_on_death ability among the kit")
+
+
+func test_aoe_on_death_has_none_returns_empty() -> void:
+	var enemy: Enemy = _make_synthetic_enemy(
+		{"mag": 20, "type": "beast", "hp": 1, "abilities": [{"id": "bite", "type": "attack"}]}
+	)
+	assert_true(
+		BattleActions.enemy_aoe_on_death_ability(enemy).is_empty(),
+		"an enemy without an aoe_on_death ability yields {}"
+	)
+
+
+func test_shard_burst_damages_whole_living_party() -> void:
+	seed(31)
+	# Two living members; a high-MAG crystal bursting at spell_power 9 hits both.
+	var state: Node = _party_members(2, {"mdef": 0, "spd": 1, "mag": 10}, 500)
+	var crystal: Enemy = _make_synthetic_enemy(
+		{
+			"mag": 40,
+			"type": "elemental",
+			"hp": 1,
+			"abilities": [{"id": "shard_burst", "aoe_on_death": true, "spell_power": 9}],
+		}
+	)
+	var ability: Dictionary = BattleActions.enemy_aoe_on_death_ability(crystal)
+	var results: Array = BattleActions.execute_aoe_on_death(state, crystal, ability)
+	assert_eq(results.size(), 2, "burst resolves against both living members")
+	var total_lost: int = 0
+	for i: int in range(2):
+		total_lost += 500 - int(state.get_member(i).get("current_hp", 500))
+	assert_gt(total_lost, 0, "the party loses HP to Shard Burst")
+
+
+# --- Integration: enemy-ability resolution through the real battle scene ---
+# These boot battle.tscn and drive the WIRED turn driver directly (bypassing the
+# AI's RNG branch) so each mechanic is proven end-to-end and deterministically.
+
+
+func _boot(encounter: Array, is_boss: bool = false) -> Node:
+	PartyState.initialize_new_game()
+	GameManager.transition_data = {
+		"return_map_id": "test_overworld",
+		"return_position": Vector2.ZERO,
+		"is_boss": is_boss,
+		"formation_type": "normal",
+		"encounter_group": encounter,
+		"enemy_act": "act_i",
+	}
+	var battle: Node = BATTLE.instantiate()
+	add_child_autofree(battle)
+	await wait_frames(3)  # let _ready build enemies + ATB
+	return battle
+
+
+func test_integration_venom_spit_inflicts_poison_on_party() -> void:
+	seed(909)
+	var battle: Node = await _boot(["marsh_serpent"])
+	var serpent: Node = battle._enemies[0]
+	var landed: bool = false
+	for _i: int in range(25):
+		battle._state.heal(0, 99999)  # keep the target alive so we can keep rolling
+		var action: Dictionary = {
+			"type": "ability",
+			"id": "venom_spit",
+			"target": "single",
+			"atk_type": "attack",
+			"target_slot": 0,
+			"ability_mult": 1.0,
+			"hits": 1,
+			"status": "poison",
+			"status_rate": 100,
+			"status_duration": null,
+		}
+		battle._enemy_turn._do_attack_or_ability(action, serpent, 0)
+		if battle._state.has_status(0, "poison"):
+			landed = true
+			break
+	assert_true(landed, "Venom Spit inflicts Poison on a party member via the wired turn driver")
+
+
+func test_integration_shard_burst_fires_on_crystal_death() -> void:
+	seed(11)
+	var battle: Node = await _boot(["unstable_crystal"])
+	var crystal: Node = battle._enemies[0]
+	var hp_before: int = 0
+	for i: int in range(4):
+		hp_before += int(battle._state.get_member(i).get("current_hp", 0))
+	crystal.take_damage(999999)  # death -> Enemy.died -> _on_enemy_died -> Shard Burst
+	await wait_frames(1)
+	var hp_after: int = 0
+	for i: int in range(4):
+		hp_after += int(battle._state.get_member(i).get("current_hp", 0))
+	assert_lt(hp_after, hp_before, "Shard Burst damages the party when the crystal dies")
+
+
+func test_integration_pack_howl_buffs_all_wolves() -> void:
+	var battle: Node = await _boot(["wayward_wolf", "wayward_wolf"])
+	var w0: Node = battle._enemies[0]
+	var w1: Node = battle._enemies[1]
+	var atk_before: int = int(w1.get_stats().get("atk", 0))
+	var action: Dictionary = {
+		"type": "ability",
+		"id": "pack_howl",
+		"target": "self",
+		"atk_type": "buff",
+		"buff": {"stat": "atk", "mult": 1.30, "duration": 5, "scope": "pack"},
+	}
+	battle._enemy_turn._do_self_ability(action, w0, battle._enemies)
+	assert_gt(
+		int(w1.get_stats().get("atk", 0)), atk_before, "Pack Howl buffs the OTHER wolf (pack scope)"
+	)
+	assert_gt(w0.active_buffs.size(), 0, "the casting wolf is buffed too")

--- a/game/tests/test_enemy_abilities.gd
+++ b/game/tests/test_enemy_abilities.gd
@@ -395,3 +395,91 @@ func test_integration_pack_howl_buffs_all_wolves() -> void:
 		int(w1.get_stats().get("atk", 0)), atk_before, "Pack Howl buffs the OTHER wolf (pack scope)"
 	)
 	assert_gt(w0.active_buffs.size(), 0, "the casting wolf is buffed too")
+
+
+# --- Round 1 review fixes (GAP-024) ---
+
+
+func test_ai_excludes_aoe_on_death_from_selection() -> void:
+	# Shard Burst (aoe_on_death) is a death trigger only — never a turn action.
+	# An enemy whose ONLY ability is aoe_on_death must fall through to defend.
+	seed(5)
+	var enemy_data: Dictionary = {
+		"abilities":
+		[
+			{
+				"id": "shard_burst",
+				"aoe_on_death": true,
+				"type": "magic",
+				"target": "all",
+				"spell_power": 9
+			}
+		]
+	}
+	var pm: Array = [{"is_alive": true, "row": "front"}, null, null, null]
+	var pr: Array = ["front", "front", "front", "front"]
+	for _i: int in range(300):
+		var a: Dictionary = BattleAI.select_action(enemy_data, pm, pr)
+		assert_ne(
+			a.get("type", ""), "ability", "aoe_on_death-only enemy never casts it as a turn action"
+		)
+
+
+func test_party_dot_tick_returns_poison_event() -> void:
+	# tick_statuses surfaces DoT so the battle layer can emit damage feedback.
+	var state: Node = _make_party(0, 0, 100)
+	state.apply_status(0, "poison", "turns", UNTIL_CURED)
+	var events: Array = state.tick_statuses(0)
+	assert_eq(events.size(), 1, "one DoT event for the single poison")
+	assert_eq(events[0].get("type", ""), "poison", "event carries the status type")
+	assert_eq(int(events[0].get("dmg", 0)), 8, "8% of 100 max HP")
+
+
+func test_integration_nonelemental_magic_aoe_uses_magic_formula() -> void:
+	seed(77)
+	var battle: Node = await _boot(["unstable_crystal"])
+	var crystal: Node = battle._enemies[0]
+	# Force the distinction: ATK 0 so a physical AoE deals ~1/member; high MAG so a
+	# magic AoE deals real damage. A non-elemental magic AoE must route through the
+	# MAG formula (the _resolve_offensive fix), not the physical ATK formula.
+	crystal.enemy_data["atk"] = 0
+	crystal.enemy_data["mag"] = 60
+	var action: Dictionary = {
+		"type": "ability",
+		"id": "x",
+		"target": "all",
+		"atk_type": "magic",
+		"element": "",
+		"power": 20
+	}
+	var before: int = 0
+	for i: int in range(4):
+		before += int(battle._state.get_member(i).get("current_hp", 0))
+	battle._enemy_turn._do_attack_or_ability(action, crystal, 0)
+	var after: int = 0
+	for i: int in range(4):
+		after += int(battle._state.get_member(i).get("current_hp", 0))
+	assert_lt(
+		after, before - 50, "non-elemental magic AoE deals MAG-based damage, not ~1/member physical"
+	)
+
+
+func test_integration_pack_howl_does_not_buff_other_species() -> void:
+	var battle: Node = await _boot(["wayward_wolf", "wild_boar"])
+	var wolf: Node = battle._enemies[0]
+	var boar: Node = battle._enemies[1]
+	var boar_atk_before: int = int(boar.get_stats().get("atk", 0))
+	var action: Dictionary = {
+		"type": "ability",
+		"id": "pack_howl",
+		"target": "self",
+		"atk_type": "buff",
+		"buff": {"stat": "atk", "mult": 1.30, "duration": 5, "scope": "pack"},
+	}
+	battle._enemy_turn._do_self_ability(action, wolf, battle._enemies)
+	assert_eq(
+		int(boar.get_stats().get("atk", 0)),
+		boar_atk_before,
+		"Pack Howl does NOT buff a different species (id mismatch)"
+	)
+	assert_gt(wolf.active_buffs.size(), 0, "the wolf itself is still buffed")


### PR DESCRIPTION
## Summary

Bundle 3a — the enemy special-abilities slice. Regular-enemy AI could previously only basic-attack or defend (the 20% ability branch always fell through because no enemy had an `abilities` array). This builds the data-driven ability-resolution layer on top of the Bundle 2b status system and Bundle 2a type-traits (reuse, not duplication).

- **GAP-024 (#166)** — `abilities[]` JSON schema + AI metadata propagation + resolution for: enemy→party offensive **status infliction** (`DamageCalc.roll_status` + `BattleState.apply_status`), **party-side DoT** tick (Poison 8%/turn) with an `UNTIL_CURED` guard, **multi-hit** + `ability_mult` power knob, **AoE-on-death** (`Enemy.died` → Shard Burst against the party), and **pack/self stat buffs** (enemy buff store applied in `get_stats()`). A **representative Act-I subset** is populated end-to-end: `marsh_serpent` (Venom Spit→Poison + Fang Strike), `unstable_crystal` (Shard Burst), `wayward_wolf` (Pack Howl + Bite), `polluted_elemental` (Frost Burst + Elemental Shield), `ember_wisp` (Flicker).
- **GAP-028 (#222)** — document the two shipped-but-undocumented Act-I enemies (`compact_patrol`, `compact_scout`) in the bestiary under a new **Ironmouth Docks** zone; bump totals 25→27 and update the README index.
- **Design is law.** The docs name every ability kit but are silent on power/rates/buff magnitudes. Rather than invent, every silent value is resolved by a new canon-derived convention doc (`enemy-ability-conventions.md`) that cites a documented analog (player spell / combat formula / status table) for each rule. Undefined mechanics (Paralysis, HP-drain, etc.) are **deferred**, not guessed.

## Type

- [x] feat — New functionality
- [x] docs — Documentation (conventions + bestiary)

## Test Plan

- [x] Pre-commit gates pass (gdlint, JSON validation, gdformat)
- [x] Pre-push gates pass (ID uniqueness, stale counts, scene refs) + full GUT suite **978 passing** (+20 new in `test_enemy_abilities.gd`, no silent skips — Scripts 59→60, Tests 958→978)
- [x] Three **integration playtests** boot the real `battle.tscn` and drive the wired enemy-turn driver: Venom Spit inflicts Poison on the party, Shard Burst fires on the crystal's death, Pack Howl buffs all wolves.

## Notes

- Follow-ups filed: **#248** (define Paralysis status), **#249** (populate the remaining ~18 Act-I ability kits), **#250** (reconcile Compact Patrol/Scout reward + HP-curve anomalies, documented as-shipped here).
- Boss AI (GAP-009) is intentionally **out of scope** — that's Bundle 3b. Legacy scripted-boss ability actions are untouched (the new resolution only activates for actions carrying the new `atk_type`/`buff`/`status` metadata).
- Every numeric value traces to `docs/story/bestiary/enemy-ability-conventions.md` and the canon it cites.

Closes #166
Closes #222

Generated with [Claude Code](https://claude.com/claude-code)
