### PR TITLE
feat(engine): Act-I enemy kits + ability selector (GAP-024 follow-ups)

### DIFF
--- a/docs/story/bestiary/act-i.md
+++ b/docs/story/bestiary/act-i.md
@@ -101,8 +101,18 @@ generally less dangerous than dungeon enemies at the same level.
 > deployments of the Soldier / Compact family** (base: Compact Soldier Lv 18,
 > documented in [act-ii.md](act-ii.md) / [palette-families.md](palette-families.md)),
 > appearing far below their projected level per the README "early deployment"
-> rule. Stats are transcribed as-shipped from `game/data/enemies/act_i.json`;
-> their reward/HP-curve anomalies are tracked as a separate balance follow-up.
+> rule. Stats are transcribed as-shipped from `game/data/enemies/act_i.json`.
+>
+> **Tutorial-encounter tuning exception (GAP-028 #250):** these two units are
+> intentionally hand-tuned for the opening story beat rather than derived from
+> the README stat/reward formulas, so they do **not** follow the curve:
+> Compact Patrol's HP (180) is deliberately above the Lv 5 curve (~125) to make
+> the scripted ambush a sturdier tutorial wall, and both units' Gold (30/35) is
+> set higher than the Low-threat reward multiplier would give (~5–6) to seed the
+> player's purse at the game's very start. Exp (18/20) is likewise hand-set. This
+> is a deliberate, documented exception — the values are correct as shipped and
+> should not be "corrected" to the formula. (Compact Scout's HP 140 is within the
+> normal Lv 6 band.)
 
 Recommended party level: 5–6.
 

--- a/docs/story/bestiary/enemy-ability-conventions.md
+++ b/docs/story/bestiary/enemy-ability-conventions.md
@@ -30,7 +30,7 @@ Each element is a dictionary:
 | `ability_mult` | float | `1.0` | Physical power multiplier (`type:"attack"`). |
 | `spell_power` | int | `0` | Magic spell power (`type:"magic"`). |
 | `target` | String | `"single"` | `"single"`, `"all"` (party-wide AoE), or `"self"`. |
-| `selector` | String | `""` | Single-target pick for regular enemies: `"back"` (a back-row member, e.g. Lunge) or `"random"` (e.g. Drift); default is the front-biased physical pick. (Boss `moves` also support `highest_threat`/`lowest_hp` via BossAI.) |
+| `selector` | String | `""` | Single-target pick. `"back"` (a back-row member, e.g. Lunge) and `"random"` (e.g. Drift) are honored by **both** regular enemies and bosses; `"highest_threat"`/`"lowest_hp"` are **boss-only** (resolved by BossAI against BattleState). Default (empty) is the front-biased physical pick. |
 | `status` | String | `""` | Status inflicted on hit (e.g. `"poison"`). |
 | `status_rate` | int | `0` | Base hit-rate fed to the two-stage roll. |
 | `status_duration` | Variant | `null` | Explicit duration override; `null` = canonical (`StatusEffects.resolve_duration`). |
@@ -206,7 +206,9 @@ These Act I kit items reference mechanics the docs do not yet define; they are
   can be implemented.
 - **Bespoke effects** with no defined magnitude: HP drain (Latch), self-destruct
   (Bloat), first-strike (Ambush), knockback (Charge), reactive counter (Thorn
-  Counter), gold theft (Steal Gold), flee (Flee), random-target (Drift).
+  Counter), gold theft (Steal Gold), flee (Flee). (Random *targeting* is now a
+  defined `selector` — see §1; only the Drift ability instance on the deferred
+  Ley Jellyfish kit remains unpopulated.)
 - **The full Act I roster.** GAP-024's first pass populates a representative
   subset proving each mechanic end-to-end; the remaining family kits are
   populated in a follow-up using the conventions above.

--- a/docs/story/bestiary/enemy-ability-conventions.md
+++ b/docs/story/bestiary/enemy-ability-conventions.md
@@ -30,6 +30,7 @@ Each element is a dictionary:
 | `ability_mult` | float | `1.0` | Physical power multiplier (`type:"attack"`). |
 | `spell_power` | int | `0` | Magic spell power (`type:"magic"`). |
 | `target` | String | `"single"` | `"single"`, `"all"` (party-wide AoE), or `"self"`. |
+| `selector` | String | `""` | Single-target pick for regular enemies: `"back"` (a back-row member, e.g. Lunge) or `"random"` (e.g. Drift); default is the front-biased physical pick. (Boss `moves` also support `highest_threat`/`lowest_hp` via BossAI.) |
 | `status` | String | `""` | Status inflicted on hit (e.g. `"poison"`). |
 | `status_rate` | int | `0` | Base hit-rate fed to the two-stage roll. |
 | `status_duration` | Variant | `null` | Explicit duration override; `null` = canonical (`StatusEffects.resolve_duration`). |

--- a/game/data/enemies/act_i.json
+++ b/game/data/enemies/act_i.json
@@ -37,7 +37,18 @@
         "ember_vein_f1",
         "ember_vein_f2"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "bite",
+          "name": "Bite",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:29)"
+        }
+      ]
     },
     {
       "id": "tomb_mite",
@@ -76,7 +87,18 @@
         "ember_vein_f1",
         "ember_vein_f2"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "nibble",
+          "name": "Nibble",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:52)"
+        }
+      ]
     },
     {
       "id": "restless_dead",
@@ -121,7 +143,18 @@
         "ember_vein_f2",
         "ember_vein_f3"
       ],
-      "ko_sound": "ko_undead"
+      "ko_sound": "ko_undead",
+      "abilities": [
+        {
+          "id": "claw",
+          "name": "Claw",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:68)"
+        }
+      ]
     },
     {
       "id": "unstable_crystal",
@@ -223,7 +256,18 @@
         "ember_vein_f2",
         "ember_vein_f3"
       ],
-      "ko_sound": "ko_spirit"
+      "ko_sound": "ko_spirit",
+      "abilities": [
+        {
+          "id": "shadow_touch",
+          "name": "Shadow Touch",
+          "type": "magic",
+          "element": "",
+          "spell_power": 14,
+          "target": "single",
+          "_comment": "MAG-based magic (element unspecified -> non-elemental); Tier-1 spell_power 14 (conventions §2.2; palette-families.md:108)"
+        }
+      ]
     },
     {
       "id": "bone_warden",
@@ -267,7 +311,31 @@
         "ember_vein_f2",
         "ember_vein_f3"
       ],
-      "ko_sound": "ko_undead"
+      "ko_sound": "ko_undead",
+      "abilities": [
+        {
+          "id": "guard_stance",
+          "name": "Guard Stance",
+          "type": "buff",
+          "target": "self",
+          "buff": {
+            "stat": "def",
+            "mult": 1.4,
+            "duration": 5,
+            "scope": "self"
+          },
+          "_comment": "Guard Stance +40% DEF/5t self; Ironhide analog (conventions §2.4; palette-families.md:132)"
+        },
+        {
+          "id": "heavy_swing",
+          "name": "Heavy Swing",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:132)"
+        }
+      ]
     },
     {
       "id": "ember_wisp",
@@ -510,7 +578,27 @@
         "fenmothers_hollow_f1",
         "fenmothers_hollow_f2"
       ],
-      "ko_sound": "ko_undead"
+      "ko_sound": "ko_undead",
+      "abilities": [
+        {
+          "id": "claw",
+          "name": "Claw",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:68)"
+        },
+        {
+          "id": "bone_toss",
+          "name": "Bone Toss",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:69)"
+        }
+      ]
     },
     {
       "id": "swamp_lurker",
@@ -550,7 +638,18 @@
         "fenmothers_hollow_f2",
         "fenmothers_hollow_f3"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "heavy_claw",
+          "name": "Heavy Claw",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:249)"
+        }
+      ]
     },
     {
       "id": "ley_jellyfish",
@@ -702,7 +801,52 @@
       "locations": [
         "fenmothers_hollow_f3"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "fang_strike",
+          "name": "Fang Strike",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:205)"
+        },
+        {
+          "id": "venom_spit",
+          "name": "Venom Spit",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "status": "poison",
+          "status_rate": 70,
+          "_comment": "Poison on hit; rate 70 (conventions §2.5); Poison 8%/turn until cured (magic.md:1392); palette-families.md:205"
+        },
+        {
+          "id": "lunge",
+          "name": "Lunge",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "selector": "back",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:206)"
+        },
+        {
+          "id": "coil",
+          "name": "Coil",
+          "type": "buff",
+          "target": "self",
+          "buff": {
+            "stat": "spd",
+            "mult": 1.5,
+            "duration": 5,
+            "scope": "self"
+          },
+          "_comment": "Coil +50% SPD/5t self; Quickstep analog (conventions §2.4; palette-families.md:206)"
+        }
+      ]
     },
     {
       "id": "plains_hare",
@@ -740,7 +884,18 @@
       "locations": [
         "valdris_plains"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "scratch",
+          "name": "Scratch",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:325)"
+        }
+      ]
     },
     {
       "id": "thornback_beetle",
@@ -778,7 +933,18 @@
       "locations": [
         "valdris_forest"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "pinch",
+          "name": "Pinch",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:346)"
+        }
+      ]
     },
     {
       "id": "road_bandit",
@@ -816,7 +982,18 @@
       "locations": [
         "valdris_road"
       ],
-      "ko_sound": "ko_humanoid"
+      "ko_sound": "ko_humanoid",
+      "abilities": [
+        {
+          "id": "slash",
+          "name": "Slash",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:363)"
+        }
+      ]
     },
     {
       "id": "forest_sprite",
@@ -859,7 +1036,18 @@
       "locations": [
         "valdris_forest"
       ],
-      "ko_sound": "ko_spirit"
+      "ko_sound": "ko_spirit",
+      "abilities": [
+        {
+          "id": "spark",
+          "name": "Spark",
+          "type": "magic",
+          "element": "ley",
+          "spell_power": 14,
+          "target": "single",
+          "_comment": "Ley ranged bolt; Tier-1 spell_power 14 (conventions §2.2; palette-families.md:388)"
+        }
+      ]
     },
     {
       "id": "wild_boar",
@@ -898,7 +1086,18 @@
         "valdris_plains",
         "forest_edge"
       ],
-      "ko_sound": "ko_beast"
+      "ko_sound": "ko_beast",
+      "abilities": [
+        {
+          "id": "gore",
+          "name": "Gore",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "_comment": "basic physical (conventions §2.1; palette-families.md:411)"
+        }
+      ]
     },
     {
       "id": "wayward_wolf",
@@ -1542,10 +1741,10 @@
           },
           "dive": {
             "type": "skip",
-            "_comment": "dive/surface untargetable cycle; Poisoned Pool hazard deferred (Phase 3 follow-up)"
+            "_comment": "dive/surface untargetable cycle; dive is a no-damage skip (the dive-mode Poisoned Pool hazard from bosses.md is not modeled — minor future polish)"
           }
         },
-        "_comment": "Phase 3 'Cleansing Sequence' (non-lethal 4-wave defense, bosses.md) is deferred to a follow-up issue."
+        "_comment": "Phases 1-2 are data-driven here; Phase 3 'Cleansing Sequence' (non-lethal 4-wave defense) is implemented in scripts/core/cleansing_sequence.gd, triggered at 0 HP via battle_manager."
       }
     }
   ]

--- a/game/scripts/combat/battle_ai.gd
+++ b/game/scripts/combat/battle_ai.gd
@@ -68,8 +68,31 @@ static func _build_ability_action(ab: Dictionary, living: Array, party_rows: Arr
 		"aoe_on_death": bool(ab.get("aoe_on_death", false)),
 	}
 	# Only single-target abilities resolve a concrete slot; all/self do not.
-	action["target_slot"] = _pick_physical_target(living, party_rows) if shape == "single" else -1
+	if shape == "single":
+		action["target_slot"] = _pick_by_selector(ab.get("selector", ""), living, party_rows)
+	else:
+		action["target_slot"] = -1
 	return action
+
+
+## Resolve a single-target selector for a regular-enemy ability. Supports "back"
+## (a living back-row member, e.g. Lunge) and "random" (any living member, e.g.
+## Drift); any other value falls back to the front-biased physical pick. Threat-
+## and HP-based selectors are boss-only (BossAI resolves those against BattleState).
+static func _pick_by_selector(selector: String, living: Array, party_rows: Array) -> int:
+	match selector:
+		"back":
+			var back: Array[int] = []
+			for slot: int in living:
+				if slot < party_rows.size() and party_rows[slot] == "back":
+					back.append(slot)
+			if not back.is_empty():
+				return back[randi() % back.size()]
+			return _pick_physical_target(living, party_rows)
+		"random":
+			return living[randi() % living.size()] if not living.is_empty() else -1
+		_:
+			return _pick_physical_target(living, party_rows)
 
 
 ## Pick a physical attack target. Prefers front row (75/25 split).

--- a/game/tests/test_enemy_abilities.gd
+++ b/game/tests/test_enemy_abilities.gd
@@ -483,3 +483,69 @@ func test_integration_pack_howl_does_not_buff_other_species() -> void:
 		"Pack Howl does NOT buff a different species (id mismatch)"
 	)
 	assert_gt(wolf.active_buffs.size(), 0, "the wolf itself is still buffed")
+
+
+# --- Regular-enemy ability selector (GAP-024 follow-up #249) ---
+
+
+func test_ability_selector_back_targets_back_row() -> void:
+	seed(123)
+	var enemy_data: Dictionary = {
+		"abilities":
+		[
+			{
+				"id": "lunge",
+				"name": "Lunge",
+				"type": "attack",
+				"target": "single",
+				"selector": "back",
+				"ability_mult": 1.0,
+			}
+		]
+	}
+	var pm: Array = [
+		{"is_alive": true, "row": "front"}, {"is_alive": true, "row": "back"}, null, null
+	]
+	var pr: Array = ["front", "back", "front", "front"]
+	var found: bool = false
+	for _i: int in range(200):
+		var a: Dictionary = BattleAI.select_action(enemy_data, pm, pr)
+		if a.get("type", "") == "ability":
+			found = true
+			assert_eq(int(a.get("target_slot", -1)), 1, "back selector targets the back-row member")
+			break
+	assert_true(found, "the 20% ability branch fired within 200 rolls")
+
+
+# --- Act-I ability data integrity (GAP-024 follow-up #249) ---
+
+
+func test_act_i_ability_data_is_well_formed() -> void:
+	var f: FileAccess = FileAccess.open("res://data/enemies/act_i.json", FileAccess.READ)
+	assert_not_null(f, "act_i.json opens")
+	var data: Variant = JSON.parse_string(f.get_as_text())
+	f.close()
+	var valid_types: Array = ["attack", "magic", "buff"]
+	var valid_stats: Array = ["atk", "def", "mag", "mdef", "spd"]
+	var valid_selectors: Array = ["", "back", "random", "lowest_hp", "highest_threat"]
+	var checked: int = 0
+	for enemy: Dictionary in data.get("enemies", []):
+		for ab: Dictionary in enemy.get("abilities", []):
+			var eid: String = enemy.get("id", "?")
+			var aid: String = ab.get("id", "?")
+			assert_true(
+				ab.get("type", "attack") in valid_types, "%s/%s has a valid type" % [eid, aid]
+			)
+			var st: String = ab.get("status", "")
+			if not st.is_empty():
+				assert_true(
+					StatusEffects.is_known(st), "%s/%s status '%s' is known" % [eid, aid, st]
+				)
+			assert_true(
+				ab.get("selector", "") in valid_selectors, "%s/%s selector valid" % [eid, aid]
+			)
+			var bf: Dictionary = ab.get("buff", {})
+			if not bf.is_empty():
+				assert_true(bf.get("stat", "") in valid_stats, "%s/%s buff stat valid" % [eid, aid])
+			checked += 1
+	assert_gt(checked, 20, "covered the populated Act-I ability set")

--- a/game/tests/test_enemy_abilities.gd
+++ b/game/tests/test_enemy_abilities.gd
@@ -517,6 +517,54 @@ func test_ability_selector_back_targets_back_row() -> void:
 	assert_true(found, "the 20% ability branch fired within 200 rolls")
 
 
+func test_ability_selector_random_targets_a_living_member() -> void:
+	seed(99)
+	var enemy_data: Dictionary = {
+		"abilities":
+		[
+			{
+				"id": "drift",
+				"name": "Drift",
+				"type": "attack",
+				"target": "single",
+				"selector": "random"
+			}
+		]
+	}
+	var pm: Array = [
+		{"is_alive": true, "row": "front"}, null, {"is_alive": true, "row": "back"}, null
+	]
+	var pr: Array = ["front", "front", "back", "front"]
+	var living: Array = [0, 2]
+	for _i: int in range(200):
+		var a: Dictionary = BattleAI.select_action(enemy_data, pm, pr)
+		if a.get("type", "") == "ability":
+			assert_true(
+				int(a.get("target_slot", -1)) in living, "random selector picks a living slot"
+			)
+			break
+
+
+func test_ability_selector_back_falls_back_when_no_back_row() -> void:
+	seed(5)
+	var enemy_data: Dictionary = {
+		"abilities":
+		[{"id": "lunge", "name": "Lunge", "type": "attack", "target": "single", "selector": "back"}]
+	}
+	# No back-row member -> "back" selector falls back to a valid front slot, never -1.
+	var pm: Array = [
+		{"is_alive": true, "row": "front"}, {"is_alive": true, "row": "front"}, null, null
+	]
+	var pr: Array = ["front", "front", "front", "front"]
+	for _i: int in range(200):
+		var a: Dictionary = BattleAI.select_action(enemy_data, pm, pr)
+		if a.get("type", "") == "ability":
+			assert_true(
+				int(a.get("target_slot", -1)) in [0, 1], "back fallback picks a living front slot"
+			)
+			break
+
+
 # --- Act-I ability data integrity (GAP-024 follow-up #249) ---
 
 
@@ -528,6 +576,7 @@ func test_act_i_ability_data_is_well_formed() -> void:
 	var valid_types: Array = ["attack", "magic", "buff"]
 	var valid_stats: Array = ["atk", "def", "mag", "mdef", "spd"]
 	var valid_selectors: Array = ["", "back", "random", "lowest_hp", "highest_threat"]
+	var valid_elements: Array = ["", "flame", "frost", "storm", "earth", "ley", "spirit", "void"]
 	var checked: int = 0
 	for enemy: Dictionary in data.get("enemies", []):
 		for ab: Dictionary in enemy.get("abilities", []):
@@ -544,6 +593,17 @@ func test_act_i_ability_data_is_well_formed() -> void:
 			assert_true(
 				ab.get("selector", "") in valid_selectors, "%s/%s selector valid" % [eid, aid]
 			)
+			# A typo'd element silently degrades to neutral (enemy.get_element_multiplier
+			# returns 1.0 for unknown), so validate it explicitly.
+			assert_true(
+				ab.get("element", "") in valid_elements,
+				"%s/%s element '%s' is canonical" % [eid, aid, ab.get("element", "")]
+			)
+			# Magic abilities must carry real power (spell_power 0 -> ~1 floor damage).
+			if ab.get("type", "") == "magic":
+				assert_gt(
+					int(ab.get("spell_power", 0)), 0, "%s/%s magic has spell_power" % [eid, aid]
+				)
 			var bf: Dictionary = ab.get("buff", {})
 			if not bf.is_empty():
 				assert_true(bf.get("stat", "") in valid_stats, "%s/%s buff stat valid" % [eid, aid])


### PR DESCRIPTION
## Summary

Bundle 4a — Act-I enemy-data completion (the actionable, low-risk slice of the combat-bundle follow-ups). Pure data/doc + a small schema extension, reusing the existing GAP-024 resolution engine.

- **#249 (straightforward subset):** added an optional `selector` (back/random) to the regular-enemy ability schema + `battle_ai`, mirroring boss `moves`, and populated **18 abilities across 13 Act-I enemies** in `act_i.json` — basic physical, single-target magic (spell_power 14), Venom Spit→Poison, Guard Stance/Coil self-buffs, Lunge (back-row). Every value cites a convention rule. New data-integrity test validates all Act-I ability type/status/selector/buff fields.
- **#250:** documented the Compact Patrol/Scout **tutorial-tuning exception** in `act-i.md` — their HP/Gold/Exp are intentionally hand-tuned for the opening ambush (not formula-derived) and correct as shipped. No data change (per design decision: transcribe-as-is + formalize).
- **#252:** corrected stale comments — Phase 3 "Cleansing Sequence" is **already implemented** (`cleansing_sequence.gd`), not deferred. (Issue closed.)

## Type
- [x] feat — selector + populated kits
- [x] docs — #250 exception, #252 comment fix

## Test Plan
- [x] Pre-commit (gdlint, JSON, gdformat) + pre-push (ID uniqueness, stale counts, scene refs) pass
- [x] Full GUT suite **1002 passing** (no silent skips); new selector + data-integrity tests
- [x] Reuses the GAP-024 engine — no new resolution paths

## Notes
Remaining #249 work split into focused issues: **#256** (bespoke abilities — drain/self-destruct/counter/flee/gold-theft/knockback) and **#257** (no-kit enemies — the_flickering, compact_patrol/scout). Paralysis (#248) + the player-side ATB-freeze engine is the next bundle (4b). #253/#254 triaged and deferred (Acts II/III, no current consumer).

Closes #250

Generated with [Claude Code](https://claude.com/claude-code)
