### PR TITLE
feat(engine): Paralysis status + auto-skip incapacitated turns (GAP-024 #248)

### DIFF
--- a/docs/story/bestiary/enemy-ability-conventions.md
+++ b/docs/story/bestiary/enemy-ability-conventions.md
@@ -200,15 +200,15 @@ covers every condition the documented format uses (`bosses.md:83-92`).
 These Act I kit items reference mechanics the docs do not yet define; they are
 **deferred** and filed as issues rather than guessed at here:
 
-- **Paralysis** (Ley Jellyfish *Ley Sting*) — referenced by
-  `palette-families.md:275` and `act-i.md:106` but **absent** from the
-  `magic.md` Status Effect Reference. A status definition is required before it
-  can be implemented.
 - **Bespoke effects** with no defined magnitude: HP drain (Latch), self-destruct
   (Bloat), first-strike (Ambush), knockback (Charge), reactive counter (Thorn
-  Counter), gold theft (Steal Gold), flee (Flee). (Random *targeting* is now a
-  defined `selector` — see §1; only the Drift ability instance on the deferred
-  Ley Jellyfish kit remains unpopulated.)
+  Counter), gold theft (Steal Gold), flee (Flee).
+
+> **Now defined (#248):** **Paralysis** — *cannot act for 3 turns, does not wake
+> on damage* — is in the `magic.md` Status Effect Reference and `status_effects.gd`
+> (`incapacitates`); the battle layer auto-skips an incapacitated member's ready
+> turn so the gauge clock counts the duration down. Ley Jellyfish (Ley Sting +
+> Drift via the `random` selector) is fully populated.
 - **The full Act I roster.** GAP-024's first pass populates a representative
   subset proving each mechanic end-to-end; the remaining family kits are
   populated in a follow-up using the conventions above.

--- a/docs/story/magic.md
+++ b/docs/story/magic.md
@@ -1398,6 +1398,7 @@ For quick reference, here are all status effects that spells in this system can 
 | Petrify | Negative | Removed from combat | Until cured | Purge, Soft Stone item |
 | Slow | Negative | ATB speed -50% | 5 turns | Purge, Chronos Dust item |
 | Stop | Negative | ATB frozen | 3 real-time seconds (not turn-based) | Wears off only |
+| Paralysis | Negative | Cannot act (does not wake on damage) | 3 turns | Cleansing Draught, Purge, Remedy item |
 | Berserk | Negative | ATB speed +25%, auto-attack random enemy with +50% basic attack damage | Until cured | Purge only |
 | Faint | Negative | Unconscious, out of combat | Until revived | Spirit Recall, Second Dawn, Phoenix Feather item, Phoenix Pinion item |
 | Despair | Negative (Void) | ATB speed -25%, damage dealt -20% | 4 turns | Hollow Mend, Pallor Salve item, Hope Shard item (rare) |

--- a/game/data/enemies/act_i.json
+++ b/game/data/enemies/act_i.json
@@ -694,7 +694,30 @@
         "fenmothers_hollow_f2",
         "fenmothers_hollow_f3"
       ],
-      "ko_sound": "ko_elemental"
+      "ko_sound": "ko_elemental",
+      "abilities": [
+        {
+          "id": "ley_sting",
+          "name": "Ley Sting",
+          "type": "magic",
+          "element": "ley",
+          "spell_power": 14,
+          "target": "single",
+          "status": "paralysis",
+          "status_rate": 70,
+          "_comment": "single-target Ley magic + Paralysis chance; spell_power 14 (conventions §2.2); rate 70 (§2.5); Paralysis 3t no-wake (status_effects.gd; #248); palette-families.md:275"
+        },
+        {
+          "id": "drift",
+          "name": "Drift",
+          "type": "attack",
+          "element": "",
+          "ability_mult": 1.0,
+          "target": "single",
+          "selector": "random",
+          "_comment": "random-target physical (conventions §2.1 + selector random; palette-families.md:275)"
+        }
+      ]
     },
     {
       "id": "polluted_elemental",

--- a/game/data/items/consumables.json
+++ b/game/data/items/consumables.json
@@ -434,7 +434,8 @@
         "blind",
         "confusion",
         "slow",
-        "petrify"
+        "petrify",
+        "paralysis"
       ],
       "buy_price": 800,
       "sell_price": 400,

--- a/game/scripts/combat/battle_manager.gd
+++ b/game/scripts/combat/battle_manager.gd
@@ -124,9 +124,15 @@ func _process(delta: float) -> void:
 	var enemy_acted: bool = false
 	for id: String in _atb.get_ready_queue():
 		if id.begins_with("party_") and _awaiting_input_for == "":
+			var slot: int = id.replace("party_", "").to_int()
+			# Incapacitated (Paralysis) members auto-skip: the status counts down on
+			# this would-be turn (the filling gauge is the clock), then the gauge
+			# resets so the next skip is one turn later (#248).
+			if _is_incapacitated(slot):
+				_skip_incapacitated_turn(slot, id)
+				continue
 			_awaiting_input_for = id
 			_atb.set_command_menu_open(true)
-			var slot: int = id.replace("party_", "").to_int()
 			var member: Dictionary = _state.get_member(slot)
 			var char_data: Dictionary = member.get("character_data", {})
 			var lc: int = _targetable_enemy_count()
@@ -211,6 +217,30 @@ func _targetable_enemy_count() -> int:
 		. filter(func(e: Node) -> bool: return e.is_alive and not e.get_meta("untargetable", false))
 		. size()
 	)
+
+
+## True if the party member cannot act (Paralysis / Sleep / Petrify) — #248.
+func _is_incapacitated(slot: int) -> bool:
+	var m: Dictionary = _state.get_member(slot)
+	if m.is_empty() or not m.get("is_alive", false):
+		return false
+	for s: Dictionary in m.get("active_statuses", []):
+		if StatusEffects.is_incapacitating(s.get("name", "")):
+			return true
+	return false
+
+
+## Auto-skip an incapacitated member's ready turn: announce, tick statuses (so the
+## turn-based countdown advances + DoT still applies), and reset the gauge so the
+## next skip is a turn away (#248).
+func _skip_incapacitated_turn(slot: int, id: String) -> void:
+	var nm: String = _state.get_member(slot).get("character_data", {}).get("name", "???")
+	message.emit("%s is paralysed and can't move!" % nm)
+	for ev: Dictionary in _state.tick_statuses(slot):
+		damage_dealt.emit(
+			"party_%d" % int(ev.get("slot", 0)), int(ev.get("dmg", 0)), ev.get("type", "poison")
+		)
+	_atb.reset_gauge(id)
 
 
 func _on_party_member_died(slot: int) -> void:

--- a/game/scripts/combat/status_effects.gd
+++ b/game/scripts/combat/status_effects.gd
@@ -30,6 +30,11 @@ const RULES: Dictionary = {
 	"sleep": {"atb": "frozen", "duration": UNTIL_CURED, "wake_on_damage": true},
 	# Petrify: removed from combat, ATB frozen, until cured (magic.md:694).
 	"petrify": {"atb": "frozen", "duration": UNTIL_CURED},
+	# Paralysis: cannot act for 3 turns, does NOT wake on damage (#248; differs
+	# from Sleep which wakes). Modeled as "incapacitates" (the gauge keeps filling
+	# so the turn-based countdown advances on each skipped would-be turn — unlike
+	# "frozen", which holds the gauge and has no clock).
+	"paralysis": {"incapacitates": true, "duration": 3, "wake_on_damage": false},
 	# Slow: ATB fill x0.5 for 5 turns (combat-formulas.md:720,732).
 	"slow": {"atb": "mod", "atb_mult": 0.5, "duration": 5},
 	# Despair: ATB fill x0.75 for 4 turns (combat-formulas.md:721,737). The
@@ -52,6 +57,14 @@ static func is_known(status: String) -> bool:
 ## ATB effect: "none", "frozen" (Sleep/Petrify), or "mod" (Slow/Despair).
 static func atb_effect(status: String) -> String:
 	return RULES.get(status, {}).get("atb", "none")
+
+
+## Whether the bearer cannot take a turn — Paralysis (explicit) or the
+## gauge-frozen action-denial statuses (Sleep/Petrify). The battle layer
+## auto-skips an incapacitated combatant's ready turn.
+static func is_incapacitating(status: String) -> bool:
+	var rule: Dictionary = RULES.get(status, {})
+	return rule.get("incapacitates", false) or rule.get("atb", "none") == "frozen"
 
 
 ## ATB fill multiplier for "mod" statuses (1.0 when none).

--- a/game/tests/test_enemy_abilities.gd
+++ b/game/tests/test_enemy_abilities.gd
@@ -114,12 +114,12 @@ func test_enemy_status_no_effect_on_dead_member() -> void:
 
 
 func test_enemy_status_unknown_is_no_effect() -> void:
-	# 'paralysis' is undefined (deferred) -> graceful no-op, never inflicted.
+	# 'stop' is deferred (not in the registry) -> graceful no-op, never inflicted.
 	var state: Node = _make_party(0, 0)
 	var enemy: Enemy = _make_enemy("marsh_serpent")
-	var r: Dictionary = BattleActions.execute_enemy_status(state, enemy, 0, 100, "paralysis", null)
+	var r: Dictionary = BattleActions.execute_enemy_status(state, enemy, 0, 100, "stop", null)
 	assert_eq(r.get("type", ""), "no_effect")
-	assert_false(state.has_status(0, "paralysis"))
+	assert_false(state.has_status(0, "stop"))
 
 
 # --- Party-side damage-over-time (Poison/Burn) ---

--- a/game/tests/test_paralysis.gd
+++ b/game/tests/test_paralysis.gd
@@ -1,0 +1,106 @@
+extends GutTest
+## Tests for the Paralysis status (#248): registry definition, turn-based
+## countdown, and the battle-layer auto-skip of an incapacitated party member's
+## ready turn. Paralysis = cannot act for 3 turns, does NOT wake on damage
+## (status_effects.gd / magic.md). The filling ATB gauge is the countdown clock.
+
+const StatusEffects = preload("res://scripts/combat/status_effects.gd")
+const BattleState = preload("res://scripts/combat/battle_state.gd")
+const BATTLE: PackedScene = preload("res://scenes/core/battle.tscn")
+
+var _booted: Node = null
+
+
+func after_each() -> void:
+	# Free any booted battle immediately so it cannot keep _process-ing into a
+	# later test file's seeded run.
+	if _booted != null and is_instance_valid(_booted):
+		_booted.set("_battle_active", false)
+		_booted.free()
+	_booted = null
+	TestHelpers.reset_game_state()
+	DataManager.clear_cache()
+	randomize()
+
+
+func _make_state() -> Node:
+	var state: Node = BattleState.new()
+	add_child_autofree(state)
+	state.add_member(0, {"character_id": "tester", "base_stats": {"hp": 100, "mp": 0}})
+	return state
+
+
+# --- Registry definition ---
+
+
+func test_paralysis_is_defined() -> void:
+	assert_true(StatusEffects.is_known("paralysis"), "paralysis is in the registry")
+	assert_eq(StatusEffects.default_duration("paralysis"), 3, "3-turn duration")
+	assert_false(StatusEffects.wakes_on_damage("paralysis"), "does NOT wake on damage")
+
+
+func test_paralysis_is_incapacitating() -> void:
+	assert_true(StatusEffects.is_incapacitating("paralysis"), "paralysis prevents acting")
+	assert_true(StatusEffects.is_incapacitating("sleep"), "frozen statuses also incapacitate")
+	assert_true(StatusEffects.is_incapacitating("petrify"), "petrify incapacitates")
+	assert_false(StatusEffects.is_incapacitating("poison"), "poison does not prevent acting")
+	assert_false(StatusEffects.is_incapacitating("slow"), "slow throttles but allows acting")
+
+
+func test_paralysis_does_not_freeze_the_gauge() -> void:
+	# Unlike Sleep/Petrify (atb "frozen"), paralysis must let the gauge fill so the
+	# turn-based countdown advances on each skipped would-be turn.
+	assert_eq(StatusEffects.atb_effect("paralysis"), "none", "paralysis is not a gauge freeze")
+
+
+# --- Turn-based countdown ---
+
+
+func test_paralysis_counts_down_and_expires() -> void:
+	var state: Node = _make_state()
+	state.apply_status(0, "paralysis", "turns", StatusEffects.default_duration("paralysis"))
+	assert_true(state.has_status(0, "paralysis"), "applied")
+	state.tick_statuses(0)
+	state.tick_statuses(0)
+	assert_true(state.has_status(0, "paralysis"), "still active after 2 of 3 ticks")
+	state.tick_statuses(0)
+	assert_false(state.has_status(0, "paralysis"), "expires after its 3rd turn")
+
+
+# --- Integration: incapacitated member auto-skips its ready turn ---
+
+
+func _boot(encounter: Array) -> Node:
+	PartyState.initialize_new_game()
+	GameManager.transition_data = {
+		"return_map_id": "test_overworld",
+		"return_position": Vector2.ZERO,
+		"is_boss": false,
+		"formation_type": "normal",
+		"encounter_group": encounter,
+		"enemy_act": "act_i",
+	}
+	var battle: Node = BATTLE.instantiate()
+	add_child(battle)
+	await wait_frames(3)
+	_booted = battle
+	return battle
+
+
+func test_integration_paralysed_member_is_skipped_and_recovers() -> void:
+	seed(31)
+	var battle: Node = await _boot(["ley_vermin"])
+	battle._state.apply_status(0, "paralysis", "turns", 3)
+	# Drive party_0's would-be turns: while paralysed it is auto-skipped (never
+	# prompted) and the status counts down; eventually it wears off.
+	for _i: int in range(8):
+		if not battle._state.has_status(0, "paralysis"):
+			break
+		battle._atb.set_gauge("party_0", 16000)
+		await wait_frames(2)
+		assert_ne(battle._awaiting_input_for, "party_0", "a paralysed member is never prompted")
+	assert_false(battle._state.has_status(0, "paralysis"), "paralysis wears off after its turns")
+	# Recovered: a now-free member fills and IS prompted.
+	battle._atb.set_gauge("party_0", 16000)
+	await wait_frames(2)
+	assert_eq(battle._awaiting_input_for, "party_0", "recovered member is prompted normally")


### PR DESCRIPTION
## Summary

Bundle 4b — define the **Paralysis** status and wire **Ley Jellyfish** (#248), the last directly-actionable combat-bundle follow-up.

- **Status definition:** `paralysis` = *cannot act for 3 turns, does NOT wake on damage* — added to `status_effects.gd` (with a new `is_incapacitating()` accessor) and the `magic.md` Status Effect Reference; `Remedy` (+ Cleansing Draught / Purge) cures it.
- **Engine — fill-and-skip (not gauge-freeze):** a ready party member who is incapacitated is **auto-skipped** in `battle_manager._process` — announced, statuses ticked (so the duration counts down + DoT still applies), gauge reset. After 3 skipped would-be turns the member recovers and is prompted normally.
  - **Why not a frozen gauge?** The ATB engine's `get_ready_queue`/`tick` only check `gauge >= max` / skip-fill-when-frozen, so a *frozen* gauge has no clock — a turn-based paralysis on a frozen gauge would be **permanent**. Letting the gauge fill and skipping the turn makes the gauge the countdown clock. This is correct and simpler than a player-side ATB-freeze subsystem.
- **Wired Ley Jellyfish:** Ley Sting (Ley magic, spell_power 14, Paralysis @ rate 70) + Drift (random-target via the Bundle-4a `selector`). Ley Jellyfish is now fully populated; convention §4 updated (Paralysis no longer deferred).

## Type
- [x] feat — new status + turn-skip engine
- [x] docs — magic.md status row, conventions §4

## Test Plan
- [x] Pre-commit (gdlint, JSON, gdformat) + pre-push (ID/stale/scene refs) pass
- [x] Full GUT suite **1009 passing** (no silent skips); new `test_paralysis.gd` — registry, 3-turn countdown, and an **integration** test booting the real battle that proves a paralysed member is auto-skipped every would-be turn and then recovers
- [x] Reuses Bundle-4a `selector` for Drift; no new resolution paths

## Notes
The broader "all party-side ATB statuses" gap (Slow/Despair fill-rate mods, Sleep on party) remains a separate concern (overlaps #246) — not needed for Paralysis. With this, the directly-actionable follow-ups are complete; remaining tracked work: #256 (bespoke abilities), #257 (no-kit enemies), #246 (GAP-003 deferrals), #253/#254 (Acts II/III boss features).

Closes #248

Generated with [Claude Code](https://claude.com/claude-code)
