### PR TITLE
feat(engine): battle + menu hp/mp fill bars and maren weave gauge

### DIFF
--- a/.claude/skills/godot-review/references/verification-checklists.md
+++ b/.claude/skills/godot-review/references/verification-checklists.md
@@ -469,6 +469,7 @@ cannot point to the exact line that handles the case, it's a bug.
 - [ ] metadata/map_id must match the scene's relative path under scenes/maps/ (e.g., "towns/roothollow" not "roothollow"). Check all new .tscn files against existing naming pattern. (PR #130: bare map_ids caused Copilot comments)
 - [ ] Test function names must match what they actually assert (e.g., "test_excludes_X" not "test_no_equipment" if only checking one item)
 - [ ] A test claiming a BEHAVIORAL property (reachable/activated/triggered/applied) must assert the behavior, not data presence — verifying an id exists in a table does not prove any input actually produces it (PR #268: "all zones activated" test only checked mapping completeness; a fully first-match-shadowed zone would still pass. Copilot caught it; both round-3 agents called the assertions "stronger than the title" without checking WHAT they asserted)
+- [ ] When one computed value feeds multiple sinks (label modulate + bar fill, text + tooltip), compute it ONCE into a local and reuse — scan each function for repeated identical helper calls, especially in per-frame paths (PR #275: hp_fill_color computed twice per row in both battle poll and menu refresh; 7 agents over 3 rounds audited allocations but missed the duplicate call — Copilot caught it)
 
 ### Source Doc Verification
 - [ ] Every value traces to a canonical doc in docs/story/

--- a/docs/issues/GAP-057-hp-mp-solid-pixel-bars-missing-in-battle-party-pan.md
+++ b/docs/issues/GAP-057-hp-mp-solid-pixel-bars-missing-in-battle-party-pan.md
@@ -8,7 +8,7 @@
 | **Type** | design-divergence |
 | **Effort** | M |
 | **Epic** | No |
-| **Status** | open — CONFIRMED |
+| **Status** | resolved — PR #275 |
 | **GitHub Issue** | [#203](https://github.com/gcko/pendulum-of-despair/issues/203) |
 | **Source domains** | ui |
 
@@ -56,3 +56,7 @@ Add HPBar/MPBar ColorRect (bg + fill) to each battle and menu Row; compute fill_
 ---
 
 _Generated 2026-06-27 by the `pod-gap-analysis` ultracode workflow (design-vs-implementation gap analysis). Verify against current code before acting._
+
+## Resolution (PR #275, 2026-07-20)
+
+Solid pixel HP/MP fill bars now render in battle party rows (new instanced scene `game/scenes/ui/battle_party_panel.tscn`) and main-menu party rows, alongside the retained numeric values. HP fill uses the shipped #44cc44 (doc lists "#44ff44 / #44cc44" ambiguously) and turns #ff4444 below 25% via the shipped integer-division idiom, centralized in `StatBarHelpers`.

--- a/docs/issues/GAP-063-maren-s-battle-weave-gauge-and-guest-npc-5th-party.md
+++ b/docs/issues/GAP-063-maren-s-battle-weave-gauge-and-guest-npc-5th-party.md
@@ -8,7 +8,7 @@
 | **Type** | missing-feature |
 | **Effort** | M |
 | **Epic** | No |
-| **Status** | open — CONFIRMED |
+| **Status** | partial — Weave Gauge shipped in PR #275; guest row moved to #272 |
 | **GitHub Issue** | [#227](https://github.com/gcko/pendulum-of-despair/issues/227) |
 | **Source domains** | ui |
 
@@ -55,3 +55,7 @@ Add a conditional WeaveBar for Maren and a 5th compact Row visible when a guest 
 ---
 
 _Generated 2026-06-27 by the `pod-gap-analysis` ultracode workflow (design-vs-implementation gap analysis). Verify against current code before acting._
+
+## Partial resolution (PR #275, 2026-07-20)
+
+Maren's purple (#aa44ff) Weave Gauge ships: thin bar below her MP bar in battle rows, fill = wg/100 from live battle state. The guest-NPC 5th row is deferred to issue #272 — the engine has no guest support (no Cordwyn/Kerra data, all party iteration capped at 4), so the row would have no data source.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -81,7 +81,7 @@ Several Act-I-scope content items were deliberately kept CONCRETE (not folded in
 | [GAP-053](GAP-053-maren-s-refuge-missing-its-basement-library-and-lo.md) | World | MEDIUM | M | open | Maren's Refuge missing its basement library and lore layer |
 | [GAP-055](GAP-055-ironmouth-implemented-as-an-escape-corridor-diverg.md) | World | MEDIUM | M | open | Ironmouth implemented as an escape corridor, diverging from the designed Carradan port city |
 | [GAP-056](GAP-056-valdris-crown-act-i-interiors-deferred-chapel-cael.md) | World | MEDIUM | M | open (overstated) | Valdris Crown Act-I interiors deferred: Chapel, Cael's Quarters, Court interiors |
-| [GAP-057](GAP-057-hp-mp-solid-pixel-bars-missing-in-battle-party-pan.md) | UI | MEDIUM | M | open | HP/MP solid pixel bars missing in battle party panel and main menu (numeric text only) |
+| [GAP-057](GAP-057-hp-mp-solid-pixel-bars-missing-in-battle-party-pan.md) | UI | MEDIUM | M | resolved (PR #275) | HP/MP solid pixel fill bars in battle party panel and main menu |
 | [GAP-058](GAP-058-32x32-character-portraits-and-menu-walking-sprites.md) | UI | MEDIUM | L | open | 32x32 character portraits and menu walking sprites not implemented in any menu/HUD |
 | [GAP-059](GAP-059-unified-8x8-status-effect-icon-system-not-rendered.md) | UI | MEDIUM | L | open | Unified 8x8 status-effect icon system not rendered anywhere |
 | [GAP-060](GAP-060-abilities-screen-lacks-character-specific-ui-and-s.md) | UI | MEDIUM | M | open | Abilities screen lacks character-specific UI and shows hardcoded resource values |
@@ -108,7 +108,7 @@ Several Act-I-scope content items were deliberately kept CONCRETE (not folded in
 | [GAP-041](GAP-041-cael-s-act-iv-grey-border-flicker-only-specified-d.md) | Dialogue | LOW | S | open | Cael's Act IV grey border flicker (only specified dialogue-box visual variation) not implemented |
 | [GAP-046](GAP-046-duplicate-divergent-chancellor-haren-dialogue-file.md) | Story | LOW | S | ✅ fixed | Duplicate, divergent Chancellor Haren dialogue files — placed NPC uses the thin stub |
 | [GAP-054](GAP-054-duskfen-settlement-unbuilt-only-the-spirit-shrine.md) | World | LOW | L | open | Duskfen settlement unbuilt — only the spirit-shrine hub exists |
-| [GAP-063](GAP-063-maren-s-battle-weave-gauge-and-guest-npc-5th-party.md) | UI | LOW | M | open | Maren's battle Weave Gauge and guest-NPC 5th party row not implemented |
+| [GAP-063](GAP-063-maren-s-battle-weave-gauge-and-guest-npc-5th-party.md) | UI | LOW | M | partial (PR #275; guest row moved to #272) | Maren's Weave Gauge shipped; guest-NPC 5th party row deferred |
 | [GAP-064](GAP-064-window-color-config-sliders-update-preview-only-ne.md) | UI | LOW | M | open | Window Color config sliders update preview only — never applied to live UI chrome |
 | [GAP-065](GAP-065-item-screen-rendered-as-single-column-without-item.md) | UI | LOW | M | open | Item screen rendered as single column without item icons (design specifies two-column grid) |
 | [GAP-074](GAP-074-multiple-config-toggles-persist-but-have-no-runtim.md) | Save | LOW | M | open | Multiple config toggles persist but have no runtime consumers (High-Res Text, Mono Audio, Transition Style, Screen Shake, always-on cues) |

--- a/docs/plans/bundle-roadmap.md
+++ b/docs/plans/bundle-roadmap.md
@@ -21,7 +21,8 @@ bundle — slice them into their own multi-PR efforts.
 | Bundle 3b | GAP-009 data-driven boss AI | ✅ merged (PR #255) |
 | Bundle 4a | Act-I enemy kits + selector schema (#249/#250) | ✅ merged (PR #258) |
 | Bundle 4b | Paralysis + player-ATB auto-skip (#248) | ✅ merged (PR #259) |
-| Bundle 5 | GAP-025 encounter scaling, GAP-026 per-tile zones, GAP-027 formation overrides | 🔄 in review |
+| Bundle 5 | GAP-025 encounter scaling, GAP-026 per-tile zones, GAP-027 formation overrides | ✅ merged (PR #268) |
+| Bundle 6 | GAP-057 HP/MP bars, GAP-063 Weave Gauge (guest row → #272) | 🔄 in review |
 
 > Bundle 2 was split after analysis: each of GAP-003/008/010 has an independent
 > "do-now" core plus a tail that depends on unbuilt systems (GAP-002 abilities,

--- a/game/scenes/core/battle.tscn
+++ b/game/scenes/core/battle.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" path="res://scripts/combat/atb_system.gd" id="2_atb"]
 [ext_resource type="Script" path="res://scripts/combat/battle_state.gd" id="3_state"]
 [ext_resource type="Script" path="res://scripts/ui/battle_ui.gd" id="4_ui"]
-[ext_resource type="Script" path="res://scripts/ui/battle_party_panel.gd" id="5_panel"]
+[ext_resource type="PackedScene" path="res://scenes/ui/battle_party_panel.tscn" id="5_panel"]
 [ext_resource type="Script" path="res://scripts/ui/battle_command_menu.gd" id="6_cmd"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBox_panel"]
@@ -50,109 +50,7 @@ zoom = Vector2(4, 4)
 layer = 10
 script = ExtResource("4_ui")
 
-[node name="PartyPanel" type="PanelContainer" parent="BattleUI"]
-offset_left = 0.0
-offset_top = 468.0
-offset_right = 832.0
-offset_bottom = 720.0
-theme_override_styles/panel = SubResource("StyleBox_panel")
-script = ExtResource("5_panel")
-
-[node name="Rows" type="VBoxContainer" parent="BattleUI/PartyPanel"]
-layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="Row0" type="HBoxContainer" parent="BattleUI/PartyPanel/Rows"]
-layout_mode = 2
-
-[node name="NameLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row0"]
-layout_mode = 2
-custom_minimum_size = Vector2(200, 0)
-text = ""
-
-[node name="HPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row0"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="MPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row0"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="ATBBar" type="ColorRect" parent="BattleUI/PartyPanel/Rows/Row0"]
-layout_mode = 2
-custom_minimum_size = Vector2(80, 16)
-color = Color(1, 0.8, 0, 1)
-
-[node name="Row1" type="HBoxContainer" parent="BattleUI/PartyPanel/Rows"]
-layout_mode = 2
-
-[node name="NameLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row1"]
-layout_mode = 2
-custom_minimum_size = Vector2(200, 0)
-text = ""
-
-[node name="HPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row1"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="MPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row1"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="ATBBar" type="ColorRect" parent="BattleUI/PartyPanel/Rows/Row1"]
-layout_mode = 2
-custom_minimum_size = Vector2(80, 16)
-color = Color(1, 0.8, 0, 1)
-
-[node name="Row2" type="HBoxContainer" parent="BattleUI/PartyPanel/Rows"]
-layout_mode = 2
-
-[node name="NameLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row2"]
-layout_mode = 2
-custom_minimum_size = Vector2(200, 0)
-text = ""
-
-[node name="HPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row2"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="MPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row2"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="ATBBar" type="ColorRect" parent="BattleUI/PartyPanel/Rows/Row2"]
-layout_mode = 2
-custom_minimum_size = Vector2(80, 16)
-color = Color(1, 0.8, 0, 1)
-
-[node name="Row3" type="HBoxContainer" parent="BattleUI/PartyPanel/Rows"]
-layout_mode = 2
-
-[node name="NameLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row3"]
-layout_mode = 2
-custom_minimum_size = Vector2(200, 0)
-text = ""
-
-[node name="HPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row3"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="MPLabel" type="Label" parent="BattleUI/PartyPanel/Rows/Row3"]
-layout_mode = 2
-custom_minimum_size = Vector2(160, 0)
-text = ""
-
-[node name="ATBBar" type="ColorRect" parent="BattleUI/PartyPanel/Rows/Row3"]
-layout_mode = 2
-custom_minimum_size = Vector2(80, 16)
-color = Color(1, 0.8, 0, 1)
+[node name="PartyPanel" parent="BattleUI" instance=ExtResource("5_panel")]
 
 [node name="CommandMenu" type="PanelContainer" parent="BattleUI"]
 offset_left = 848.0

--- a/game/scenes/overlay/menu.tscn
+++ b/game/scenes/overlay/menu.tscn
@@ -66,15 +66,39 @@ text = "EDREN"
 custom_minimum_size = Vector2(80, 0)
 text = "LV 1"
 
-[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row0"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row0"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row0/HPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = "HP 95/95"
 
-[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row0"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row0/HPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row0/HPCluster/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row0"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row0/MPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = "MP 15/15"
+
+[node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row0/MPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row0/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
 
 [node name="Row1" type="HBoxContainer" parent="MainPanel/Margin/Rows"]
 size_flags_vertical = 3
@@ -89,15 +113,39 @@ text = "CAEL"
 custom_minimum_size = Vector2(80, 0)
 text = "LV 1"
 
-[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row1"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row1"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row1/HPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = "HP 78/78"
 
-[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row1"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row1/HPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row1/HPCluster/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row1"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row1/MPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = "MP 25/25"
+
+[node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row1/MPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row1/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
 
 [node name="Row2" type="HBoxContainer" parent="MainPanel/Margin/Rows"]
 size_flags_vertical = 3
@@ -112,15 +160,39 @@ text = ""
 custom_minimum_size = Vector2(80, 0)
 text = ""
 
-[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row2"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row2"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row2/HPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = ""
 
-[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row2"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row2/HPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row2/HPCluster/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row2"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row2/MPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = ""
+
+[node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row2/MPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row2/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
 
 [node name="Row3" type="HBoxContainer" parent="MainPanel/Margin/Rows"]
 size_flags_vertical = 3
@@ -135,15 +207,39 @@ text = ""
 custom_minimum_size = Vector2(80, 0)
 text = ""
 
-[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row3"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row3"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="HPLabel" type="Label" parent="MainPanel/Margin/Rows/Row3/HPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = ""
 
-[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row3"]
-custom_minimum_size = Vector2(160, 0)
+[node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row3/HPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row3/HPCluster/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPCluster" type="VBoxContainer" parent="MainPanel/Margin/Rows/Row3"]
 size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="MPLabel" type="Label" parent="MainPanel/Margin/Rows/Row3/MPCluster"]
+custom_minimum_size = Vector2(160, 0)
 text = ""
+
+[node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row3/MPCluster"]
+custom_minimum_size = Vector2(240, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="MainPanel/Margin/Rows/Row3/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
 
 [node name="CommandPanel" type="PanelContainer" parent="."]
 offset_left = 888.0

--- a/game/scenes/overlay/menu.tscn
+++ b/game/scenes/overlay/menu.tscn
@@ -75,6 +75,7 @@ custom_minimum_size = Vector2(160, 0)
 text = "HP 95/95"
 
 [node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row0/HPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0.133, 0, 0, 1)
 
@@ -92,6 +93,7 @@ custom_minimum_size = Vector2(160, 0)
 text = "MP 15/15"
 
 [node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row0/MPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0, 0.067, 0.133, 1)
 
@@ -122,6 +124,7 @@ custom_minimum_size = Vector2(160, 0)
 text = "HP 78/78"
 
 [node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row1/HPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0.133, 0, 0, 1)
 
@@ -139,6 +142,7 @@ custom_minimum_size = Vector2(160, 0)
 text = "MP 25/25"
 
 [node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row1/MPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0, 0.067, 0.133, 1)
 
@@ -169,6 +173,7 @@ custom_minimum_size = Vector2(160, 0)
 text = ""
 
 [node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row2/HPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0.133, 0, 0, 1)
 
@@ -186,6 +191,7 @@ custom_minimum_size = Vector2(160, 0)
 text = ""
 
 [node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row2/MPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0, 0.067, 0.133, 1)
 
@@ -216,6 +222,7 @@ custom_minimum_size = Vector2(160, 0)
 text = ""
 
 [node name="HPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row3/HPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0.133, 0, 0, 1)
 
@@ -233,6 +240,7 @@ custom_minimum_size = Vector2(160, 0)
 text = ""
 
 [node name="MPBarBg" type="ColorRect" parent="MainPanel/Margin/Rows/Row3/MPCluster"]
+size_flags_horizontal = 0
 custom_minimum_size = Vector2(240, 12)
 color = Color(0, 0.067, 0.133, 1)
 

--- a/game/scenes/ui/battle_party_panel.tscn
+++ b/game/scenes/ui/battle_party_panel.tscn
@@ -1,0 +1,291 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/battle_party_panel.gd" id="1_panel"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_panel"]
+bg_color = Color(0, 0, 0.251, 1)
+border_width_left = 8
+border_width_top = 8
+border_width_right = 8
+border_width_bottom = 8
+border_color = Color(0.333, 0.4, 0.667, 1)
+content_margin_left = 16.0
+content_margin_top = 8.0
+content_margin_right = 16.0
+content_margin_bottom = 8.0
+
+[node name="PartyPanel" type="PanelContainer"]
+offset_left = 0.0
+offset_top = 468.0
+offset_right = 832.0
+offset_bottom = 720.0
+theme_override_styles/panel = SubResource("StyleBox_panel")
+script = ExtResource("1_panel")
+
+[node name="Rows" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Row0" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="Rows/Row0"]
+layout_mode = 2
+custom_minimum_size = Vector2(140, 0)
+text = ""
+
+[node name="HPLabel" type="Label" parent="Rows/Row0"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="HPBarBg" type="ColorRect" parent="Rows/Row0"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(120, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="Rows/Row0/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPLabel" type="Label" parent="Rows/Row0"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="MPCluster" type="VBoxContainer" parent="Rows/Row0"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 2
+
+[node name="MPBarBg" type="ColorRect" parent="Rows/Row0/MPCluster"]
+layout_mode = 2
+custom_minimum_size = Vector2(120, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="Rows/Row0/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
+
+[node name="WeaveBarBg" type="ColorRect" parent="Rows/Row0/MPCluster"]
+visible = false
+layout_mode = 2
+custom_minimum_size = Vector2(120, 6)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="WeaveBarFill" type="ColorRect" parent="Rows/Row0/MPCluster/WeaveBarBg"]
+offset_right = 0.0
+offset_bottom = 6.0
+color = Color(0.667, 0.267, 1, 1)
+
+[node name="ATBBarBg" type="ColorRect" parent="Rows/Row0"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(80, 16)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="ATBBarFill" type="ColorRect" parent="Rows/Row0/ATBBarBg"]
+offset_right = 0.0
+offset_bottom = 16.0
+color = Color(1, 0.8, 0, 1)
+
+[node name="Row1" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="Rows/Row1"]
+layout_mode = 2
+custom_minimum_size = Vector2(140, 0)
+text = ""
+
+[node name="HPLabel" type="Label" parent="Rows/Row1"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="HPBarBg" type="ColorRect" parent="Rows/Row1"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(120, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="Rows/Row1/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPLabel" type="Label" parent="Rows/Row1"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="MPCluster" type="VBoxContainer" parent="Rows/Row1"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 2
+
+[node name="MPBarBg" type="ColorRect" parent="Rows/Row1/MPCluster"]
+layout_mode = 2
+custom_minimum_size = Vector2(120, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="Rows/Row1/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
+
+[node name="WeaveBarBg" type="ColorRect" parent="Rows/Row1/MPCluster"]
+visible = false
+layout_mode = 2
+custom_minimum_size = Vector2(120, 6)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="WeaveBarFill" type="ColorRect" parent="Rows/Row1/MPCluster/WeaveBarBg"]
+offset_right = 0.0
+offset_bottom = 6.0
+color = Color(0.667, 0.267, 1, 1)
+
+[node name="ATBBarBg" type="ColorRect" parent="Rows/Row1"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(80, 16)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="ATBBarFill" type="ColorRect" parent="Rows/Row1/ATBBarBg"]
+offset_right = 0.0
+offset_bottom = 16.0
+color = Color(1, 0.8, 0, 1)
+
+[node name="Row2" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="Rows/Row2"]
+layout_mode = 2
+custom_minimum_size = Vector2(140, 0)
+text = ""
+
+[node name="HPLabel" type="Label" parent="Rows/Row2"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="HPBarBg" type="ColorRect" parent="Rows/Row2"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(120, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="Rows/Row2/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPLabel" type="Label" parent="Rows/Row2"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="MPCluster" type="VBoxContainer" parent="Rows/Row2"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 2
+
+[node name="MPBarBg" type="ColorRect" parent="Rows/Row2/MPCluster"]
+layout_mode = 2
+custom_minimum_size = Vector2(120, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="Rows/Row2/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
+
+[node name="WeaveBarBg" type="ColorRect" parent="Rows/Row2/MPCluster"]
+visible = false
+layout_mode = 2
+custom_minimum_size = Vector2(120, 6)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="WeaveBarFill" type="ColorRect" parent="Rows/Row2/MPCluster/WeaveBarBg"]
+offset_right = 0.0
+offset_bottom = 6.0
+color = Color(0.667, 0.267, 1, 1)
+
+[node name="ATBBarBg" type="ColorRect" parent="Rows/Row2"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(80, 16)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="ATBBarFill" type="ColorRect" parent="Rows/Row2/ATBBarBg"]
+offset_right = 0.0
+offset_bottom = 16.0
+color = Color(1, 0.8, 0, 1)
+
+[node name="Row3" type="HBoxContainer" parent="Rows"]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="Rows/Row3"]
+layout_mode = 2
+custom_minimum_size = Vector2(140, 0)
+text = ""
+
+[node name="HPLabel" type="Label" parent="Rows/Row3"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="HPBarBg" type="ColorRect" parent="Rows/Row3"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(120, 12)
+color = Color(0.133, 0, 0, 1)
+
+[node name="HPBarFill" type="ColorRect" parent="Rows/Row3/HPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.8, 0.267, 1)
+
+[node name="MPLabel" type="Label" parent="Rows/Row3"]
+layout_mode = 2
+custom_minimum_size = Vector2(110, 0)
+text = ""
+
+[node name="MPCluster" type="VBoxContainer" parent="Rows/Row3"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 2
+
+[node name="MPBarBg" type="ColorRect" parent="Rows/Row3/MPCluster"]
+layout_mode = 2
+custom_minimum_size = Vector2(120, 12)
+color = Color(0, 0.067, 0.133, 1)
+
+[node name="MPBarFill" type="ColorRect" parent="Rows/Row3/MPCluster/MPBarBg"]
+offset_right = 0.0
+offset_bottom = 12.0
+color = Color(0.267, 0.533, 1, 1)
+
+[node name="WeaveBarBg" type="ColorRect" parent="Rows/Row3/MPCluster"]
+visible = false
+layout_mode = 2
+custom_minimum_size = Vector2(120, 6)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="WeaveBarFill" type="ColorRect" parent="Rows/Row3/MPCluster/WeaveBarBg"]
+offset_right = 0.0
+offset_bottom = 6.0
+color = Color(0.667, 0.267, 1, 1)
+
+[node name="ATBBarBg" type="ColorRect" parent="Rows/Row3"]
+layout_mode = 2
+size_flags_vertical = 4
+custom_minimum_size = Vector2(80, 16)
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="ATBBarFill" type="ColorRect" parent="Rows/Row3/ATBBarBg"]
+offset_right = 0.0
+offset_bottom = 16.0
+color = Color(1, 0.8, 0, 1)

--- a/game/scenes/ui/battle_party_panel.tscn
+++ b/game/scenes/ui/battle_party_panel.tscn
@@ -30,11 +30,13 @@ theme_override_constants/separation = 8
 layout_mode = 2
 
 [node name="NameLabel" type="Label" parent="Rows/Row0"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(140, 0)
 text = ""
 
 [node name="HPLabel" type="Label" parent="Rows/Row0"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -51,6 +53,7 @@ offset_bottom = 12.0
 color = Color(0.267, 0.8, 0.267, 1)
 
 [node name="MPLabel" type="Label" parent="Rows/Row0"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -96,11 +99,13 @@ color = Color(1, 0.8, 0, 1)
 layout_mode = 2
 
 [node name="NameLabel" type="Label" parent="Rows/Row1"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(140, 0)
 text = ""
 
 [node name="HPLabel" type="Label" parent="Rows/Row1"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -117,6 +122,7 @@ offset_bottom = 12.0
 color = Color(0.267, 0.8, 0.267, 1)
 
 [node name="MPLabel" type="Label" parent="Rows/Row1"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -162,11 +168,13 @@ color = Color(1, 0.8, 0, 1)
 layout_mode = 2
 
 [node name="NameLabel" type="Label" parent="Rows/Row2"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(140, 0)
 text = ""
 
 [node name="HPLabel" type="Label" parent="Rows/Row2"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -183,6 +191,7 @@ offset_bottom = 12.0
 color = Color(0.267, 0.8, 0.267, 1)
 
 [node name="MPLabel" type="Label" parent="Rows/Row2"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -228,11 +237,13 @@ color = Color(1, 0.8, 0, 1)
 layout_mode = 2
 
 [node name="NameLabel" type="Label" parent="Rows/Row3"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(140, 0)
 text = ""
 
 [node name="HPLabel" type="Label" parent="Rows/Row3"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""
@@ -249,6 +260,7 @@ offset_bottom = 12.0
 color = Color(0.267, 0.8, 0.267, 1)
 
 [node name="MPLabel" type="Label" parent="Rows/Row3"]
+vertical_alignment = 1
 layout_mode = 2
 custom_minimum_size = Vector2(110, 0)
 text = ""

--- a/game/scripts/ui/battle_party_panel.gd
+++ b/game/scripts/ui/battle_party_panel.gd
@@ -1,67 +1,115 @@
 extends PanelContainer
-## Renders party member rows in battle: name, HP/MP bars, ATB gauge, status icons.
+## Renders party member rows in battle: name, HP/MP numerics + solid
+## pixel fill bars, Maren's Weave Gauge, and the ATB gauge
+## (ui-design.md § 2.1/2.3/2.9). Scene: scenes/ui/battle_party_panel.tscn.
+## Updated by BattleUI's per-frame poll — stays pull-based because MP
+## changes emit no signals.
 
-const COLOR_HP_FILL: Color = Color("#44cc44")
-const COLOR_HP_LOW: Color = Color("#ff4444")
-const COLOR_MP_FILL: Color = Color("#4488ff")
-const COLOR_ATB_FILL: Color = Color("#ffcc00")
+const ATBSystemScript = preload("res://scripts/combat/atb_system.gd")
+
 const COLOR_NAME_NORMAL: Color = Color("#ffffff")
 const COLOR_NAME_ACTIVE: Color = Color("#ffff88")
 
-var _rows: Array = [null, null, null, null]
+## Weave Gauge maximum charge (abilities.md: WG 0-100).
+const WEAVE_MAX: int = 100
+
+## Per-row node caches (Dictionary of refs), filled once in _ready so the
+## per-frame poll does no get_node_or_null lookups.
+var _rows: Array = [{}, {}, {}, {}]
 var _active_slot: int = -1
 
 
 func _ready() -> void:
-	var rows_container: VBoxContainer = get_node_or_null("Rows")
 	for i: int in range(4):
-		var path: String = "Rows/Row%d" % i if rows_container != null else "Row%d" % i
-		var row: HBoxContainer = get_node_or_null(path)
-		_rows[i] = row
+		_rows[i] = _cache_row(get_node_or_null("Rows/Row%d" % i))
 
 
 ## Update all party rows from state data.
 func update_party(members: Array, gauges: Dictionary) -> void:
 	for i: int in range(4):
-		if _rows[i] == null:
+		var refs: Dictionary = _rows[i]
+		if refs.is_empty():
 			continue
+		var row: HBoxContainer = refs["row"]
 		var m: Dictionary = members[i] if i < members.size() and members[i] is Dictionary else {}
 		if m.is_empty():
-			_rows[i].visible = false
+			row.visible = false
 			continue
-		_rows[i].visible = true
+		row.visible = true
 		_update_row(i, m, gauges.get("party_%d" % i, 0))
-
-
-func _update_row(slot: int, member: Dictionary, atb_gauge: int) -> void:
-	var row: HBoxContainer = _rows[slot]
-	if row == null:
-		return
-
-	var name_label: Label = row.get_node_or_null("NameLabel")
-	if name_label != null:
-		name_label.text = member.get("character_data", {}).get("name", "???")
-		name_label.modulate = COLOR_NAME_ACTIVE if slot == _active_slot else COLOR_NAME_NORMAL
-
-	var hp_label: Label = row.get_node_or_null("HPLabel")
-	if hp_label != null:
-		var hp: int = member.get("current_hp", 0)
-		var max_hp: int = member.get("max_hp", 1)
-		hp_label.text = "%d/%d" % [hp, max_hp]
-		hp_label.modulate = COLOR_HP_LOW if hp < max_hp / 4 else COLOR_HP_FILL
-
-	var mp_label: Label = row.get_node_or_null("MPLabel")
-	if mp_label != null:
-		mp_label.text = "%d/%d" % [member.get("current_mp", 0), member.get("max_mp", 0)]
-		mp_label.modulate = COLOR_MP_FILL
-
-	var atb_bar: ColorRect = row.get_node_or_null("ATBBar")
-	if atb_bar != null:
-		var fill_ratio: float = clampf(float(atb_gauge) / 16000.0, 0.0, 1.0)
-		atb_bar.custom_minimum_size.x = fill_ratio * 80.0
-		atb_bar.color = COLOR_ATB_FILL
 
 
 ## Set which party member is currently acting.
 func set_active_slot(slot: int) -> void:
 	_active_slot = slot
+
+
+func _cache_row(row: HBoxContainer) -> Dictionary:
+	if row == null:
+		return {}
+	return {
+		"row": row,
+		"name_label": row.get_node_or_null("NameLabel"),
+		"hp_label": row.get_node_or_null("HPLabel"),
+		"hp_bg": row.get_node_or_null("HPBarBg"),
+		"hp_fill": row.get_node_or_null("HPBarBg/HPBarFill"),
+		"mp_label": row.get_node_or_null("MPLabel"),
+		"mp_bg": row.get_node_or_null("MPCluster/MPBarBg"),
+		"mp_fill": row.get_node_or_null("MPCluster/MPBarBg/MPBarFill"),
+		"weave_bg": row.get_node_or_null("MPCluster/WeaveBarBg"),
+		"weave_fill": row.get_node_or_null("MPCluster/WeaveBarBg/WeaveBarFill"),
+		"atb_bg": row.get_node_or_null("ATBBarBg"),
+		"atb_fill": row.get_node_or_null("ATBBarBg/ATBBarFill"),
+	}
+
+
+func _update_row(slot: int, member: Dictionary, atb_gauge: int) -> void:
+	var refs: Dictionary = _rows[slot]
+
+	var name_label: Label = refs["name_label"]
+	if name_label != null:
+		name_label.text = member.get("character_data", {}).get("name", "???")
+		name_label.modulate = COLOR_NAME_ACTIVE if slot == _active_slot else COLOR_NAME_NORMAL
+
+	var hp: int = member.get("current_hp", 0)
+	var max_hp: int = member.get("max_hp", 1)
+	var hp_label: Label = refs["hp_label"]
+	if hp_label != null:
+		hp_label.text = "%d/%d" % [hp, max_hp]
+		hp_label.modulate = StatBarHelpers.hp_fill_color(hp, max_hp)
+	_set_fill(refs, "hp", hp, max_hp)
+	var hp_fill: ColorRect = refs["hp_fill"]
+	if hp_fill != null:
+		hp_fill.color = StatBarHelpers.hp_fill_color(hp, max_hp)
+
+	var mp: int = member.get("current_mp", 0)
+	var max_mp: int = member.get("max_mp", 0)
+	var mp_label: Label = refs["mp_label"]
+	if mp_label != null:
+		mp_label.text = "%d/%d" % [mp, max_mp]
+		mp_label.modulate = StatBarHelpers.COLOR_MP_FILL
+	_set_fill(refs, "mp", mp, max_mp)
+
+	_update_weave(refs, member)
+	_set_fill(refs, "atb", atb_gauge, ATBSystemScript.GAUGE_MAX)
+
+
+## Maren-only Weave Gauge below the MP bar (ui-design.md § 2.9).
+func _update_weave(refs: Dictionary, member: Dictionary) -> void:
+	var weave_bg: ColorRect = refs["weave_bg"]
+	if weave_bg == null:
+		return
+	var shows: bool = StatBarHelpers.shows_weave_gauge(member.get("character_id", ""))
+	weave_bg.visible = shows
+	if shows:
+		_set_fill(refs, "weave", member.get("wg", 0), WEAVE_MAX)
+
+
+## Size a fill rect against its track's authored width — deterministic
+## under headless container layout.
+func _set_fill(refs: Dictionary, key: String, current: int, max_value: int) -> void:
+	var bg: ColorRect = refs["%s_bg" % key]
+	var fill: ColorRect = refs["%s_fill" % key]
+	if bg == null or fill == null:
+		return
+	fill.size.x = StatBarHelpers.fill_width(current, max_value, bg.custom_minimum_size.x)

--- a/game/scripts/ui/battle_party_panel.gd
+++ b/game/scripts/ui/battle_party_panel.gd
@@ -77,14 +77,15 @@ func _update_row(slot: int, member: Dictionary, atb_gauge: int) -> void:
 
 	var hp: int = member.get("current_hp", 0)
 	var max_hp: int = member.get("max_hp", 1)
+	var hp_color: Color = StatBarHelpers.hp_fill_color(hp, max_hp)
 	var hp_label: Label = refs["hp_label"]
 	if hp_label != null:
 		hp_label.text = "%d/%d" % [hp, max_hp]
-		hp_label.modulate = StatBarHelpers.hp_fill_color(hp, max_hp)
+		hp_label.modulate = hp_color
 	_set_fill(refs["hp_bg"], refs["hp_fill"], hp, max_hp)
 	var hp_fill: ColorRect = refs["hp_fill"]
 	if hp_fill != null:
-		hp_fill.color = StatBarHelpers.hp_fill_color(hp, max_hp)
+		hp_fill.color = hp_color
 
 	var mp: int = member.get("current_mp", 0)
 	var max_mp: int = member.get("max_mp", 0)

--- a/game/scripts/ui/battle_party_panel.gd
+++ b/game/scripts/ui/battle_party_panel.gd
@@ -107,6 +107,9 @@ func _update_weave(refs: Dictionary, member: Dictionary) -> void:
 	weave_bg.visible = shows
 	if shows:
 		_set_fill(refs["weave_bg"], refs["weave_fill"], member.get("wg", 0), WEAVE_MAX)
+		var weave_fill: ColorRect = refs["weave_fill"]
+		if weave_fill != null:
+			weave_fill.color = StatBarHelpers.COLOR_WEAVE_FILL
 
 
 ## Size a fill rect against its track's authored width — deterministic

--- a/game/scripts/ui/battle_party_panel.gd
+++ b/game/scripts/ui/battle_party_panel.gd
@@ -13,6 +13,10 @@ const COLOR_NAME_ACTIVE: Color = Color("#ffff88")
 ## Weave Gauge maximum charge (abilities.md: WG 0-100).
 const WEAVE_MAX: int = 100
 
+## Precomputed ATB gauge keys — update_party runs in a per-frame poll,
+## so avoid rebuilding "party_%d" strings every frame.
+const PARTY_KEYS: Array[String] = ["party_0", "party_1", "party_2", "party_3"]
+
 ## Per-row node caches (Dictionary of refs), filled once in _ready so the
 ## per-frame poll does no get_node_or_null lookups.
 var _rows: Array = [{}, {}, {}, {}]
@@ -36,7 +40,7 @@ func update_party(members: Array, gauges: Dictionary) -> void:
 			row.visible = false
 			continue
 		row.visible = true
-		_update_row(i, m, gauges.get("party_%d" % i, 0))
+		_update_row(i, m, gauges.get(PARTY_KEYS[i], 0))
 
 
 ## Set which party member is currently acting.
@@ -77,7 +81,7 @@ func _update_row(slot: int, member: Dictionary, atb_gauge: int) -> void:
 	if hp_label != null:
 		hp_label.text = "%d/%d" % [hp, max_hp]
 		hp_label.modulate = StatBarHelpers.hp_fill_color(hp, max_hp)
-	_set_fill(refs, "hp", hp, max_hp)
+	_set_fill(refs["hp_bg"], refs["hp_fill"], hp, max_hp)
 	var hp_fill: ColorRect = refs["hp_fill"]
 	if hp_fill != null:
 		hp_fill.color = StatBarHelpers.hp_fill_color(hp, max_hp)
@@ -88,10 +92,10 @@ func _update_row(slot: int, member: Dictionary, atb_gauge: int) -> void:
 	if mp_label != null:
 		mp_label.text = "%d/%d" % [mp, max_mp]
 		mp_label.modulate = StatBarHelpers.COLOR_MP_FILL
-	_set_fill(refs, "mp", mp, max_mp)
+	_set_fill(refs["mp_bg"], refs["mp_fill"], mp, max_mp)
 
 	_update_weave(refs, member)
-	_set_fill(refs, "atb", atb_gauge, ATBSystemScript.GAUGE_MAX)
+	_set_fill(refs["atb_bg"], refs["atb_fill"], atb_gauge, ATBSystemScript.GAUGE_MAX)
 
 
 ## Maren-only Weave Gauge below the MP bar (ui-design.md § 2.9).
@@ -102,14 +106,12 @@ func _update_weave(refs: Dictionary, member: Dictionary) -> void:
 	var shows: bool = StatBarHelpers.shows_weave_gauge(member.get("character_id", ""))
 	weave_bg.visible = shows
 	if shows:
-		_set_fill(refs, "weave", member.get("wg", 0), WEAVE_MAX)
+		_set_fill(refs["weave_bg"], refs["weave_fill"], member.get("wg", 0), WEAVE_MAX)
 
 
 ## Size a fill rect against its track's authored width — deterministic
 ## under headless container layout.
-func _set_fill(refs: Dictionary, key: String, current: int, max_value: int) -> void:
-	var bg: ColorRect = refs["%s_bg" % key]
-	var fill: ColorRect = refs["%s_fill" % key]
+func _set_fill(bg: ColorRect, fill: ColorRect, current: int, max_value: int) -> void:
 	if bg == null or fill == null:
 		return
 	fill.size.x = StatBarHelpers.fill_width(current, max_value, bg.custom_minimum_size.x)

--- a/game/scripts/ui/menu_overlay.gd
+++ b/game/scripts/ui/menu_overlay.gd
@@ -322,11 +322,12 @@ func _update_party_row(slot: int, member: Dictionary) -> void:
 
 	var hp: int = member.get("current_hp", 0)
 	var max_hp: int = member.get("max_hp", 1)
+	var hp_color: Color = StatBarHelpers.hp_fill_color(hp, max_hp)
 	var hp_label: Label = row.get_node_or_null("HPCluster/HPLabel")
 	if hp_label != null:
 		hp_label.text = "HP %d/%d" % [hp, max_hp]
-		hp_label.modulate = StatBarHelpers.hp_fill_color(hp, max_hp)
-	_set_bar_fill(row, "HPCluster/HPBarBg", hp, max_hp, StatBarHelpers.hp_fill_color(hp, max_hp))
+		hp_label.modulate = hp_color
+	_set_bar_fill(row, "HPCluster/HPBarBg", hp, max_hp, hp_color)
 
 	var mp: int = member.get("current_mp", 0)
 	var max_mp: int = member.get("max_mp", 0)

--- a/game/scripts/ui/menu_overlay.gd
+++ b/game/scripts/ui/menu_overlay.gd
@@ -7,9 +7,6 @@ enum MenuState { COMMAND, CHARACTER_SELECT, SUB_SCREEN }
 const COLOR_SELECTED: Color = Color("#ffff88")
 const COLOR_NORMAL: Color = Color("#ccddff")
 const COLOR_DISABLED: Color = Color("#666688")
-const COLOR_HP: Color = Color("#44cc44")
-const COLOR_HP_LOW: Color = Color("#ff4444")
-const COLOR_MP: Color = Color("#4488ff")
 const COLOR_GOLD: Color = Color("#ffcc44")
 const COLOR_WINDOW_BG: Color = Color("#000040")
 
@@ -336,7 +333,7 @@ func _update_party_row(slot: int, member: Dictionary) -> void:
 	var mp_label: Label = row.get_node_or_null("MPCluster/MPLabel")
 	if mp_label != null:
 		mp_label.text = "MP %d/%d" % [mp, max_mp]
-		mp_label.modulate = COLOR_MP
+		mp_label.modulate = StatBarHelpers.COLOR_MP_FILL
 	_set_bar_fill(row, "MPCluster/MPBarBg", mp, max_mp, StatBarHelpers.COLOR_MP_FILL)
 
 

--- a/game/scripts/ui/menu_overlay.gd
+++ b/game/scripts/ui/menu_overlay.gd
@@ -323,17 +323,37 @@ func _update_party_row(slot: int, member: Dictionary) -> void:
 	if lv_label != null:
 		lv_label.text = "LV %d" % member.get("level", 1)
 
-	var hp_label: Label = row.get_node_or_null("HPLabel")
+	var hp: int = member.get("current_hp", 0)
+	var max_hp: int = member.get("max_hp", 1)
+	var hp_label: Label = row.get_node_or_null("HPCluster/HPLabel")
 	if hp_label != null:
-		var hp: int = member.get("current_hp", 0)
-		var max_hp: int = member.get("max_hp", 1)
 		hp_label.text = "HP %d/%d" % [hp, max_hp]
-		hp_label.modulate = COLOR_HP_LOW if hp < max_hp / 4 else COLOR_HP
+		hp_label.modulate = StatBarHelpers.hp_fill_color(hp, max_hp)
+	_set_bar_fill(row, "HPCluster/HPBarBg", hp, max_hp, StatBarHelpers.hp_fill_color(hp, max_hp))
 
-	var mp_label: Label = row.get_node_or_null("MPLabel")
+	var mp: int = member.get("current_mp", 0)
+	var max_mp: int = member.get("max_mp", 0)
+	var mp_label: Label = row.get_node_or_null("MPCluster/MPLabel")
 	if mp_label != null:
-		mp_label.text = "MP %d/%d" % [member.get("current_mp", 0), member.get("max_mp", 0)]
+		mp_label.text = "MP %d/%d" % [mp, max_mp]
 		mp_label.modulate = COLOR_MP
+	_set_bar_fill(row, "MPCluster/MPBarBg", mp, max_mp, StatBarHelpers.COLOR_MP_FILL)
+
+
+## Solid pixel fill bars alongside the numerics (ui-design.md § 3.3).
+## Fill width is set against the track's authored width — deterministic
+## under headless container layout.
+func _set_bar_fill(
+	row: Control, bg_path: String, current: int, max_value: int, fill_color: Color
+) -> void:
+	var bg: ColorRect = row.get_node_or_null(bg_path)
+	if bg == null:
+		return
+	var fill: ColorRect = bg.get_node_or_null("%sFill" % bg_path.get_file().trim_suffix("Bg"))
+	if fill == null:
+		return
+	fill.size.x = StatBarHelpers.fill_width(current, max_value, bg.custom_minimum_size.x)
+	fill.color = fill_color
 
 
 func _clear_char_highlight() -> void:

--- a/game/scripts/ui/menu_status.gd
+++ b/game/scripts/ui/menu_status.gd
@@ -3,9 +3,6 @@ extends Control
 
 const Helpers = preload("res://scripts/autoload/inventory_helpers.gd")
 const COLOR_NORMAL: Color = Color("#ccddff")
-const COLOR_HP: Color = Color("#44cc44")
-const COLOR_HP_LOW: Color = Color("#ff4444")
-const COLOR_MP: Color = Color("#4488ff")
 
 const STAT_NAMES: Array[String] = ["atk", "def", "mag", "mdef", "spd", "lck"]
 const STAT_DISPLAY: Array[String] = ["ATK", "DEF", "MAG", "MDEF", "SPD", "LCK"]
@@ -93,10 +90,10 @@ func _update_display() -> void:
 	var max_hp: int = member.get("max_hp", 1)
 	if _hp_label != null:
 		_hp_label.text = "HP %d/%d" % [hp, max_hp]
-		_hp_label.modulate = COLOR_HP_LOW if hp < max_hp / 4 else COLOR_HP
+		_hp_label.modulate = StatBarHelpers.hp_fill_color(hp, max_hp)
 	if _mp_label != null:
 		_mp_label.text = "MP %d/%d" % [member.get("current_mp", 0), member.get("max_mp", 0)]
-		_mp_label.modulate = COLOR_MP
+		_mp_label.modulate = StatBarHelpers.COLOR_MP_FILL
 
 	# Core stats
 	for i: int in range(_stat_labels.size()):

--- a/game/scripts/ui/stat_bar_helpers.gd
+++ b/game/scripts/ui/stat_bar_helpers.gd
@@ -1,0 +1,35 @@
+class_name StatBarHelpers
+extends RefCounted
+## Pure helpers for solid pixel stat-fill bars (ui-design.md § 1.2 "one
+## modern addition", § 2.1/2.3 battle rows, § 3.3 menu rows).
+## Bar geometry is set against the track's custom_minimum_size so fills
+## stay deterministic under headless container layout.
+
+## HP fill/text green. ui-design.md:76 lists "#44ff44 / #44cc44" without
+## assigning which is fill — we keep the shipped #44cc44 everywhere.
+const COLOR_HP_FILL: Color = Color("#44cc44")
+## Low-HP warning (< 25% of max), bar fill AND numeric text.
+const COLOR_HP_LOW: Color = Color("#ff4444")
+const COLOR_MP_FILL: Color = Color("#4488ff")
+## Maren's Weave Gauge fill (ui-design.md § 2.9).
+const COLOR_WEAVE_FILL: Color = Color("#aa44ff")
+
+
+## Fill width in pixels for a stat bar. Clamps to [0, bar_width]; a
+## non-positive max renders an empty bar instead of dividing by zero.
+static func fill_width(current: int, max_value: int, bar_width: float) -> float:
+	if max_value <= 0:
+		return 0.0
+	return clampf(float(current) / float(max_value), 0.0, 1.0) * bar_width
+
+
+## HP fill color: low-HP red below 25% of max, using the shipped
+## integer-division idiom (hp < max_hp / 4) so bar and numeric text
+## flip on the same frame.
+static func hp_fill_color(hp: int, max_hp: int) -> Color:
+	return COLOR_HP_LOW if hp < max_hp / 4 else COLOR_HP_FILL
+
+
+## Only Maren carries the Weave Gauge (ui-design.md § 2.9).
+static func shows_weave_gauge(character_id: String) -> bool:
+	return character_id == "maren"

--- a/game/tests/test_battle_party_panel_bars.gd
+++ b/game/tests/test_battle_party_panel_bars.gd
@@ -96,3 +96,21 @@ func test_empty_member_hides_row() -> void:
 	_panel.update_party([_member(400, 800), {}], {"party_0": 0})
 	var row1: HBoxContainer = _panel.get_node_or_null("Rows/Row1")
 	assert_false(row1.visible, "empty member dict hides the whole row")
+
+
+func test_active_slot_highlights_name() -> void:
+	_panel.set_active_slot(0)
+	_panel.update_party([_member(400, 800)], {"party_0": 0})
+	var name_label: Label = _row_node(0, "NameLabel")
+	assert_eq(name_label.modulate, _panel.COLOR_NAME_ACTIVE, "acting member's name lights up")
+	_panel.set_active_slot(-1)
+	_panel.update_party([_member(400, 800)], {"party_0": 0})
+	assert_eq(name_label.modulate, _panel.COLOR_NAME_NORMAL, "cleared slot restores normal")
+
+
+func test_missing_name_falls_back_to_placeholder() -> void:
+	var member: Dictionary = _member(400, 800)
+	member["character_data"] = {}
+	_panel.update_party([member], {"party_0": 0})
+	var name_label: Label = _row_node(0, "NameLabel")
+	assert_eq(name_label.text, "???", "missing name renders the placeholder")

--- a/game/tests/test_battle_party_panel_bars.gd
+++ b/game/tests/test_battle_party_panel_bars.gd
@@ -1,0 +1,98 @@
+extends GutTest
+## Tests for battle party-panel stat bars (GAP-057) and Maren's Weave
+## Gauge (GAP-063). Instantiates the standalone panel scene directly —
+## no battle boot, so the seed(7) playtest RNG stream is untouched.
+
+const PANEL_SCENE: PackedScene = preload("res://scenes/ui/battle_party_panel.tscn")
+const ATBSystemScript = preload("res://scripts/combat/atb_system.gd")
+
+var _panel: PanelContainer
+
+
+func before_each() -> void:
+	_panel = PANEL_SCENE.instantiate()
+	add_child_autofree(_panel)
+
+
+func after_each() -> void:
+	_panel = null
+
+
+func _member(
+	hp: int, max_hp: int, mp: int = 10, max_mp: int = 80, cid: String = "edren"
+) -> Dictionary:
+	return {
+		"character_id": cid,
+		"character_data": {"name": cid.capitalize()},
+		"current_hp": hp,
+		"max_hp": max_hp,
+		"current_mp": mp,
+		"max_mp": max_mp,
+		"wg": 0,
+	}
+
+
+func _row_node(slot: int, path: String) -> Node:
+	return _panel.get_node_or_null("Rows/Row%d/%s" % [slot, path])
+
+
+func test_hp_bar_fill_reflects_ratio() -> void:
+	_panel.update_party([_member(400, 800)], {"party_0": 0})
+	var fill: ColorRect = _row_node(0, "HPBarBg/HPBarFill")
+	var bg: ColorRect = _row_node(0, "HPBarBg")
+	assert_eq(fill.size.x, 0.5 * bg.custom_minimum_size.x, "half HP fills half the bar")
+
+
+func test_hp_bar_turns_red_below_quarter() -> void:
+	_panel.update_party([_member(199, 800)], {"party_0": 0})
+	var fill: ColorRect = _row_node(0, "HPBarBg/HPBarFill")
+	assert_eq(fill.color, StatBarHelpers.COLOR_HP_LOW, "below 25% is red")
+	var hp_label: Label = _row_node(0, "HPLabel")
+	assert_eq(hp_label.modulate, StatBarHelpers.COLOR_HP_LOW, "numeric text matches")
+
+
+func test_hp_bar_green_at_exact_quarter() -> void:
+	_panel.update_party([_member(200, 800)], {"party_0": 0})
+	var fill: ColorRect = _row_node(0, "HPBarBg/HPBarFill")
+	assert_eq(fill.color, StatBarHelpers.COLOR_HP_FILL, "exactly 25% stays green")
+
+
+func test_ko_member_renders_empty_hp_bar() -> void:
+	_panel.update_party([_member(0, 800)], {"party_0": 0})
+	var fill: ColorRect = _row_node(0, "HPBarBg/HPBarFill")
+	assert_eq(fill.size.x, 0.0, "KO renders an honest empty bar")
+
+
+func test_mp_bar_empty_but_track_visible() -> void:
+	_panel.update_party([_member(800, 800, 0, 80)], {"party_0": 0})
+	var fill: ColorRect = _row_node(0, "MPCluster/MPBarBg/MPBarFill")
+	var bg: ColorRect = _row_node(0, "MPCluster/MPBarBg")
+	assert_eq(fill.size.x, 0.0, "0 MP is an empty fill")
+	assert_true(bg.visible, "the track still shows the empty state")
+
+
+func test_weave_gauge_visible_only_for_maren() -> void:
+	var maren: Dictionary = _member(300, 300, 40, 80, "maren")
+	maren["wg"] = 50
+	_panel.update_party([maren, _member(400, 800)], {"party_0": 0, "party_1": 0})
+	var weave_bg: ColorRect = _row_node(0, "MPCluster/WeaveBarBg")
+	var weave_fill: ColorRect = _row_node(0, "MPCluster/WeaveBarBg/WeaveBarFill")
+	assert_true(weave_bg.visible, "Maren's row shows the Weave Gauge")
+	assert_eq(weave_fill.size.x, 0.5 * weave_bg.custom_minimum_size.x, "WG 50/100 is half")
+	var other_weave: ColorRect = _row_node(1, "MPCluster/WeaveBarBg")
+	assert_false(other_weave.visible, "non-Maren rows hide the gauge")
+
+
+func test_atb_fill_uses_gauge_max_constant() -> void:
+	_panel.update_party([_member(800, 800)], {"party_0": ATBSystemScript.GAUGE_MAX})
+	var fill: ColorRect = _row_node(0, "ATBBarBg/ATBBarFill")
+	var bg: ColorRect = _row_node(0, "ATBBarBg")
+	assert_eq(fill.size.x, bg.custom_minimum_size.x, "full gauge fills the track")
+	_panel.update_party([_member(800, 800)], {"party_0": ATBSystemScript.GAUGE_MAX / 2})
+	assert_eq(fill.size.x, 0.5 * bg.custom_minimum_size.x, "half gauge is half")
+
+
+func test_empty_member_hides_row() -> void:
+	_panel.update_party([_member(400, 800), {}], {"party_0": 0})
+	var row1: HBoxContainer = _panel.get_node_or_null("Rows/Row1")
+	assert_false(row1.visible, "empty member dict hides the whole row")

--- a/game/tests/test_battle_party_panel_bars.gd
+++ b/game/tests/test_battle_party_panel_bars.gd
@@ -63,12 +63,10 @@ func test_ko_member_renders_empty_hp_bar() -> void:
 	assert_eq(fill.size.x, 0.0, "KO renders an honest empty bar")
 
 
-func test_mp_bar_empty_but_track_visible() -> void:
+func test_mp_bar_empty_renders_zero_width_fill() -> void:
 	_panel.update_party([_member(800, 800, 0, 80)], {"party_0": 0})
 	var fill: ColorRect = _row_node(0, "MPCluster/MPBarBg/MPBarFill")
-	var bg: ColorRect = _row_node(0, "MPCluster/MPBarBg")
-	assert_eq(fill.size.x, 0.0, "0 MP is an empty fill")
-	assert_true(bg.visible, "the track still shows the empty state")
+	assert_eq(fill.size.x, 0.0, "0 MP is an empty fill over the visible track")
 
 
 func test_weave_gauge_visible_only_for_maren() -> void:

--- a/game/tests/test_helpers.gd
+++ b/game/tests/test_helpers.gd
@@ -39,3 +39,5 @@ static func reset_game_state() -> void:
 	PartyState.ley_crystals.clear()
 	PartyState.puzzle_state.clear()
 	PartyState.is_at_save_point = false
+	PartyState.playtime = 0
+	PartyState.location_name = ""

--- a/game/tests/test_menu_party_bars.gd
+++ b/game/tests/test_menu_party_bars.gd
@@ -65,3 +65,4 @@ func test_menu_numeric_labels_remain() -> void:
 	var hp_label: Label = _row0_node("HPCluster/HPLabel")
 	assert_not_null(hp_label, "numeric HP label stays alongside the bar")
 	assert_eq(hp_label.text, "HP 100/400", "numeric value keeps rendering")
+	assert_true(hp_label.visible, "label is not hidden by the bar layout")

--- a/game/tests/test_menu_party_bars.gd
+++ b/game/tests/test_menu_party_bars.gd
@@ -1,0 +1,67 @@
+extends GutTest
+## Tests for main-menu party-row HP/MP fill bars (GAP-057).
+## Calls _update_party_row directly with fabricated member dicts so no
+## PartyState seeding is needed.
+
+const MENU_SCENE: PackedScene = preload("res://scenes/overlay/menu.tscn")
+const TestHelpers = preload("res://tests/test_helpers.gd")
+
+var _menu: Node
+
+
+func before_each() -> void:
+	TestHelpers.reset_game_state()
+	_menu = MENU_SCENE.instantiate()
+	add_child_autofree(_menu)
+
+
+func after_each() -> void:
+	_menu = null
+	TestHelpers.reset_game_state()
+
+
+func _fake_member(hp: int, max_hp: int, mp: int, max_mp: int) -> Dictionary:
+	return {
+		"character_id": "edren",
+		"level": 5,
+		"current_hp": hp,
+		"max_hp": max_hp,
+		"current_mp": mp,
+		"max_mp": max_mp,
+	}
+
+
+func _row0_node(path: String) -> Node:
+	return _menu.get_node_or_null("MainPanel/Margin/Rows/Row0/%s" % path)
+
+
+func test_menu_hp_bar_fill_and_low_color() -> void:
+	_menu._update_party_row(0, _fake_member(99, 400, 10, 80))
+	var bg: ColorRect = _row0_node("HPCluster/HPBarBg")
+	var fill: ColorRect = _row0_node("HPCluster/HPBarBg/HPBarFill")
+	assert_not_null(bg, "menu row should have an HP bar track")
+	assert_not_null(fill, "menu row should have an HP bar fill")
+	assert_almost_eq(fill.size.x, 0.2475 * bg.custom_minimum_size.x, 0.001, "99/400 fills 24.75%")
+	assert_eq(fill.color, StatBarHelpers.COLOR_HP_LOW, "below 25% is low, bar turns red")
+
+
+func test_menu_hp_bar_green_when_healthy() -> void:
+	_menu._update_party_row(0, _fake_member(400, 400, 10, 80))
+	var fill: ColorRect = _row0_node("HPCluster/HPBarBg/HPBarFill")
+	assert_not_null(fill)
+	assert_eq(fill.color, StatBarHelpers.COLOR_HP_FILL, "healthy HP stays green")
+
+
+func test_menu_mp_bar_fill() -> void:
+	_menu._update_party_row(0, _fake_member(400, 400, 10, 80))
+	var bg: ColorRect = _row0_node("MPCluster/MPBarBg")
+	var fill: ColorRect = _row0_node("MPCluster/MPBarBg/MPBarFill")
+	assert_not_null(fill, "menu row should have an MP bar fill")
+	assert_eq(fill.size.x, 0.125 * bg.custom_minimum_size.x, "10/80 MP fills an eighth")
+
+
+func test_menu_numeric_labels_remain() -> void:
+	_menu._update_party_row(0, _fake_member(100, 400, 10, 80))
+	var hp_label: Label = _row0_node("HPCluster/HPLabel")
+	assert_not_null(hp_label, "numeric HP label stays alongside the bar")
+	assert_eq(hp_label.text, "HP 100/400", "numeric value keeps rendering")

--- a/game/tests/test_stat_bar_helpers.gd
+++ b/game/tests/test_stat_bar_helpers.gd
@@ -1,0 +1,39 @@
+extends GutTest
+## Tests for StatBarHelpers pure bar math (GAP-057/GAP-063).
+## Threshold canon: HP bar/text turn red below 25% of max
+## (ui-design.md low-HP warning), matching the shipped integer-division
+## idiom hp < max_hp / 4.
+
+const SBH = preload("res://scripts/ui/stat_bar_helpers.gd")
+
+
+func test_fill_width_half() -> void:
+	assert_eq(SBH.fill_width(400, 800, 120.0), 60.0, "half HP fills half the bar")
+
+
+func test_fill_width_full_and_overflow_clamp() -> void:
+	assert_eq(SBH.fill_width(800, 800, 120.0), 120.0, "full fills the whole bar")
+	assert_eq(SBH.fill_width(900, 800, 120.0), 120.0, "overflow clamps to bar width")
+
+
+func test_fill_width_zero_and_negative_clamp() -> void:
+	assert_eq(SBH.fill_width(0, 800, 120.0), 0.0, "zero HP is an empty bar")
+	assert_eq(SBH.fill_width(-5, 800, 120.0), 0.0, "negative clamps to empty")
+
+
+func test_fill_width_zero_max_no_division_error() -> void:
+	assert_eq(SBH.fill_width(10, 0, 120.0), 0.0, "max 0 must not divide by zero")
+	assert_eq(SBH.fill_width(10, -1, 120.0), 0.0, "negative max is empty")
+
+
+func test_hp_fill_color_boundary_matches_shipped_idiom() -> void:
+	# Shipped idiom: hp < max_hp / 4 with integer division.
+	assert_eq(SBH.hp_fill_color(200, 800), SBH.COLOR_HP_FILL, "exactly 25% is NOT low")
+	assert_eq(SBH.hp_fill_color(199, 800), SBH.COLOR_HP_LOW, "below 25% is low")
+	assert_eq(SBH.hp_fill_color(800, 800), SBH.COLOR_HP_FILL, "full HP is green")
+
+
+func test_weave_gauge_only_for_maren() -> void:
+	assert_true(SBH.shows_weave_gauge("maren"), "Maren shows the Weave Gauge")
+	assert_false(SBH.shows_weave_gauge("edren"), "others do not")
+	assert_false(SBH.shows_weave_gauge(""), "empty id does not")


### PR DESCRIPTION
## Summary

- **GAP-057 (#203):** the design's explicitly-flagged "one modern addition" — solid pixel HP/MP fill bars alongside the numeric values — now renders in both battle party rows and main-menu party rows. HP fill is #44cc44 (the shipped constant; ui-design.md lists "#44ff44 / #44cc44" ambiguously — noted for a doc clarification) and turns #ff4444 below 25% of max using the shipped integer-division idiom, so bar and numeric text flip on the same frame. MP fills #4488ff. Fill widths are set against each track's authored width, deterministic under headless layout.
- **GAP-063 (#227, Weave half):** Maren's rows show the thin purple (#aa44ff) Weave Gauge below her MP bar, reading the live battle `wg` resource (accumulates +5/+10/+15 on real casts). The spend path stays with the abilities-execution gap. The guest-NPC 5th row half is split to #272 — the engine has zero guest support (no data files, everything iterates range(4)), so a row today would be dead pixels; "Refs" not "Closes".
- **Structural:** the battle party panel is extracted from battle.tscn into its own instanced scene (`scenes/ui/battle_party_panel.tscn`) — reusable-behavior-as-scene per the architecture checklist, and standalone-testable without booting a battle (protecting the seed(7) playtest RNG stream). The panel script now caches row node refs in `_ready` (removing ~16 per-frame `get_node_or_null` lookups from the battle UI poll), the ATB bar gains a proper track (it previously collapsed to nothing at gauge 0), and the `16000.0` magic number is replaced by `ATBSystem.GAUGE_MAX`.

Six design decisions locked with the user before implementation (guest-row deferral, weave-now, both greens/#44cc44, red on bar+text, bars-in-place over 2-line restructure, bar dimensions as tunable constants). Follow-ups filed: #272 guest NPC battle support, #273 2-line row layout + status icons + bar polish, #274 pre-existing level-up max_hp equipment-bonus drop (bars make it visible).

Closes #203. Refs #227 (Weave Gauge shipped; guest row tracked in #272).

## Type

- [x] feat — New functionality

## Test Plan

- [x] Full GUT suite green: 68 scripts / 1081 tests (baseline 65/1063; +3 scripts, +18 tests — Scripts/Tests counts verified against GUT's silent parse-skip)
- [x] `test_combat_playtest` seed(7) canary passes unmodified (panel tests instantiate the standalone scene; no battle boot, no RNG)
- [x] New tests: pure bar math incl. boundary semantics (hp == max/4 green, max/4 − 1 red, zero-max no div-by-zero), battle panel fills/colors/KO/weave visibility/ATB GAUGE_MAX, menu row fills + numeric labels retained
- [x] Pre-commit (gdlint, gdformat, JSON) and pre-push (data scans + import + full suite) gates pass

## Notes

Bar dimensions are spec-silent (docs give only relative cues) and were chosen as tunable constants: battle HP/MP 120x12, Weave 120x6, ATB 80x16; menu 240x12 stacked under the numerics (two 240px bars beside four labels would overflow the 864px panel). Visual pass happens in the next playtest; all fills/colors/visibility are assertion-covered. menu.tscn row labels moved into HPCluster/MPCluster VBoxes — node names preserved for the structure-scrape guards.

Generated with [Claude Code](https://claude.ai/code)
